### PR TITLE
add syntax highlighting

### DIFF
--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -309,6 +309,9 @@
     }
   };
 </script>
+<!--Import syntax highlighting-->
+{@html '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css"></script>'}
+{@html '<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>'}
 
 <nav class="level chat-header">
   <div class="level-left">


### PR DESCRIPTION
Your app is awesome. I started writing my own but yours already has all the features that I wanted to add. 
But one thing was missing: Syntax highlighting. 

In my forked version I added 3 lines of code that makes all the code blocks syntax highlighted as in an IDE:

I've never used Svelte before so it may not be the optimal way to do it. But it seems to work. 