### PR TITLE
Add timing of requests. Add small animation showing time elapsed for request.

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -39,6 +39,27 @@ a.is-disabled {
   width: fit-content;
 }
 
+article.user-message {
+  position: relative;
+}
+
+.timer_popout {
+  position: absolute;
+  top:50%;
+  height: 100%;
+  transform: translate(-0%,-50%);
+  z-index: -1;
+  transition: all 500ms ease;
+  &.message-body {
+    border-width: 0 0 0 0 !important;
+  }
+
+  &.open{
+    transform: translate(-90%,-50%);
+  }
+
+}
+
 .assistant-message {
   max-width: 90%;
   width: fit-content;
@@ -53,6 +74,11 @@ a.is-disabled {
 /* Swap the border on user messages to the other side */
 .user-message > .message-body {
   border-width: 0 4px 0 0 !important;
+}
+
+/* Remove the border on the timer popout */
+.user-message > .message-body.timer_popout {
+  border-width: 0 0 0 0 !important;
 }
 
 /* Show the edit button on hover of the chat name */

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -20,6 +20,7 @@
     content: string;
     usage?: Usage;
     model?: Model;
+    timeTaken?: number;
   };
 
   export type Chat = {


### PR DESCRIPTION
The app needs a bit more feedback. Since we already give feedback on the cost, the time would be the next logical step. 
This commit starts a timer when the request starts, every 1/10th of second it increments the time and displays that in a little box that folds out of the latest user message (the question).

The time the request took is written on each message that has that info along with cost, model etc.

I meant to make the timing and the animation two different PRs, but the `setInterval` approach to timing only makes sense if you want to show the time ticking up in near real time. Otherwise it would be much better to use a simple t1-t0 approach view `Date.getTime()` 

I know setInterval is 100% accurate for measuring time, but its good enough for this purpose.