### PR TITLE
Minor best practice tweaks

### DIFF
--- a/mocked_api/Dockerfile-mockapi
+++ b/mocked_api/Dockerfile-mockapi
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.10.10-alpine3.17
 WORKDIR /work
 
 RUN pip install fastapi uvicorn lorem-text

--- a/mocked_api/Dockerfile-mockapi
+++ b/mocked_api/Dockerfile-mockapi
@@ -1,7 +1,7 @@
 FROM python:3.10.10-alpine3.17
 WORKDIR /work
 
-RUN pip install fastapi uvicorn lorem-text
+RUN pip install "fastapi<1.0" "uvicorn<0.22" "lorem-text<=2.1.x"
 COPY mocked_api/mock_api.py .
 COPY mocked_api/models_response.json .
 


### PR DESCRIPTION
Lock the python version in the alpine image.
Lock the packages.

Although was a small risk, now we know it won't break because some package or image was updated.