### PR TITLE
add confirmation prompt before deleting all chats

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -41,14 +41,13 @@
       >
     </li>
     <li>
-      <a
-        href={'#/'}
-        class="panel-block"
+      <a class="panel-block"
         class:is-disabled={!$apiKeyStorage}
         on:click={() => {
-          replace('#/').then(() => {
-            clearChats()
-          })
+          const confirmDelete = window.confirm('Are you sure you want to delete all your chats?')
+          if (confirmDelete) {
+            replace('#/').then(() => clearChats())
+          }
         }}><span class="greyscale mr-2">🗑️</span> Clear chats</a
       >
     </li>


### PR DESCRIPTION
Right now if you click "clear chats" it just does it without any fanfare.. 
Someone may have a lot of chats, but now they could all be deleted by a mis-click.
This add a confirmation prompt.