### PR TITLE
Force short suggested names; rename from chat menu; hidden prompt prefix

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -231,16 +231,16 @@ $modal-background-background-color-dark: rgba($dark, 0.86) !default; // remove t
 
 .menu-list {
   a:hover {
-    .delete-button {
+    .delete-button, .edit-button {
       display: block !important;
       background-color: initial;
     }
   }
-  .delete-button {
+  .delete-button, .edit-button {
     opacity: .8;
   }
   
-  .delete-button:hover {
+  .delete-button:hover, .edit-button {
     opacity: 1;
   }
 }
@@ -319,6 +319,17 @@ $modal-background-background-color-dark: rgba($dark, 0.86) !default; // remove t
   position: absolute;
   right: .4em;
   z-index: 200;
+}
+
+.chat-menu-item .edit-button {
+  position: absolute;
+  right: 2em;
+  z-index: 200;
+}
+
+.chat-name-editor {
+  margin: .5em;
+  padding:.1em;
 }
 
 /* Overrides for main layout  */

--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -37,7 +37,7 @@
     faLightbulb,
     faCommentSlash
   } from '@fortawesome/free-solid-svg-icons/index'
-  // import { encode } from 'gpt-tokenizer'
+  import { encode } from 'gpt-tokenizer'
   import { v4 as uuidv4 } from 'uuid'
   import { countPromptTokens, getModelMaxTokens, getPrice } from './Stats.svelte'
   import { autoGrowInputOnEvent, scrollToMessage, sizeTextElements } from './Util.svelte'
@@ -184,11 +184,15 @@
     let filtered = messages.filter(messageFilter)
   
     // Get an estimate of the total prompt size we're sending
-    const promptTokenCount:number = countPromptTokens(filtered, model)
+    let promptTokenCount:number = countPromptTokens(filtered, model)
   
     let summarySize = chatSettings.summarySize
 
     const hiddenPromptPrefix = mergeProfileFields(chatSettings, chatSettings.hiddenPromptPrefix).trim()
+  
+    if (hiddenPromptPrefix && filtered.length && filtered[filtered.length - 1].role === 'user') {
+      promptTokenCount += encode(hiddenPromptPrefix + '\n\n').length
+    }
 
     // console.log('Estimated',promptTokenCount,'prompt token for this request')
 

--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -555,7 +555,7 @@
   const suggestName = async (): Promise<void> => {
     const suggestMessage: Message = {
       role: 'user',
-      content: "Can you give me a 5 word summary of this conversation's topic?",
+      content: "Using appropriate language, please give a 5 word summary of this conversation's topic.",
       uuid: uuidv4()
     }
 
@@ -565,7 +565,9 @@
     const response = await sendRequest(suggestMessages, {
       chat,
       autoAddMessages: false,
-      streaming: false
+      streaming: false,
+      summaryRequest: true,
+      maxTokens: 10
     })
     await response.promiseToFinish()
 
@@ -577,10 +579,10 @@
       })
     } else {
       response.getMessages().forEach(m => {
-        chat.name = m.content
+        const name = m.content.split(/\s+/).slice(0, 8).join(' ').trim()
+        if (name) chat.name = name
       })
       saveChatStore()
-      $checkStateChange++
     }
   }
 

--- a/src/lib/Profiles.svelte
+++ b/src/lib/Profiles.svelte
@@ -70,22 +70,25 @@ export const getProfile = (key:string, forReset:boolean = false):ChatSettings =>
     return clone
 }
 
+export const mergeProfileFields = (settings: ChatSettings, content: string|undefined, maxWords: number|undefined = undefined): string => {
+    if (!content?.toString) return ''
+    content = (content + '').replaceAll('[[CHARACTER_NAME]]', settings.characterName || 'ChatGPT')
+    if (maxWords) content = (content + '').replaceAll('[[MAX_WORDS]]', maxWords.toString())
+    return content
+}
+
 export const prepareProfilePrompt = (chatId:number) => {
     const settings = getChatSettings(chatId)
-    const characterName = settings.characterName
-    const currentProfilePrompt = settings.systemPrompt
-    return currentProfilePrompt.replaceAll('[[CHARACTER_NAME]]', characterName)
+    return mergeProfileFields(settings, settings.systemPrompt).trim()
 }
 
 export const prepareSummaryPrompt = (chatId:number, promptsSize:number, maxTokens:number|undefined = undefined) => {
     const settings = getChatSettings(chatId)
-    const characterName = settings.characterName || 'ChatGPT'
     maxTokens = maxTokens || settings.summarySize
     maxTokens = Math.min(Math.floor(promptsSize / 4), maxTokens) // Make sure we're shrinking by at least a 4th
     const currentSummaryPrompt = settings.summaryPrompt
-    return currentSummaryPrompt
-      .replaceAll('[[CHARACTER_NAME]]', characterName)
-      .replaceAll('[[MAX_WORDS]]', Math.floor(maxTokens * 0.75).toString()) // ~.75 words per token.  May need to reduce
+    // ~.75 words per token.  May need to reduce
+    return mergeProfileFields(settings, currentSummaryPrompt, Math.floor(maxTokens * 0.75)).trim()
 }
 
 // Restart currently loaded profile

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -84,6 +84,7 @@ const defaults:ChatSettings = {
   systemPrompt: '',
   autoStartSession: false,
   trainingPrompts: [],
+  hiddenPromptPrefix: '',
   // useResponseAlteration: false,
   // responseAlterations: [],
   isDirty: false
@@ -164,6 +165,14 @@ const systemPromptSettings: ChatSetting[] = [
         name: 'System Prompt',
         title: 'First prompt to send.',
         placeholder: 'Enter the first prompt to send here.  You can tell ChatGPT how to act.',
+        type: 'textarea',
+        hide: (chatId) => !getChatSettings(chatId).useSystemPrompt
+      },
+      {
+        key: 'hiddenPromptPrefix',
+        name: 'Hidden Prompt Prefix',
+        title: 'A prompt that will be silently injected before every user prompt.',
+        placeholder: 'Enter user prompt prefix here.  You can remind ChatGPT how to act.',
         type: 'textarea',
         hide: (chatId) => !getChatSettings(chatId).useSystemPrompt
       },

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -58,7 +58,6 @@
     profileName: string,
     profileDescription: string,
     continuousChat: (''|'fifo'|'summary');
-    // useSummarization: boolean;
     summaryThreshold: number;
     summarySize: number;
     pinTop: number;
@@ -67,6 +66,7 @@
     useSystemPrompt: boolean;
     systemPrompt: string;
     autoStartSession: boolean;
+    hiddenPromptPrefix: string;
     trainingPrompts?: Message[];
     useResponseAlteration?: boolean;
     responseAlterations?: ResponseAlteration[];


### PR DESCRIPTION
This adds:

- Short chat name suggestions.  Previously, depending on the content a name was being requested for, ChatGPT could return a much longer response than requested making the name so long you couldn't even get to the edit button.  This stops that.
- There's now a pencil icon on chat menu item hover to allow rename in place, similar to official ChatGPT.
- There's a new "Hidden Prompt Prefix" setting.  Any text entered there will be injected as a prefix to the last prompt in the request if it's a user prompt.  It will not be visible in chat, and will not be resent. One use case is to continually remind ChatGPT to stay character when responding.
