### PR TITLE
Add image generation, new gpt-3.5 models and fix #172

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "bulma": "^0.9.4",
         "bulma-prefers-dark": "^0.1.0-beta.1",
         "copy-to-clipboard": "^3.3.3",
+        "dexie": "^4.0.1-alpha.20",
         "eslint-config-standard-with-typescript": "^35.0.0",
         "eslint-plugin-svelte3": "^4.0.0",
         "flourite": "^1.2.3",
@@ -1600,6 +1601,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dexie": {
+      "version": "4.0.1-alpha.20",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.1-alpha.20.tgz",
+      "integrity": "sha512-q/nMsCQiTWTmnw11aseJLfAsGQ/9t05sjWltgw1/r2TbfnIkmfjdTt8ATSIwmtKXuSznEZ5czazvL5LO5rR+6w==",
+      "dev": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bulma": "^0.9.4",
     "bulma-prefers-dark": "^0.1.0-beta.1",
     "copy-to-clipboard": "^3.3.3",
+    "dexie": "^4.0.1-alpha.20",
     "eslint-config-standard-with-typescript": "^35.0.0",
     "eslint-plugin-svelte3": "^4.0.0",
     "flourite": "^1.2.3",

--- a/src/app.scss
+++ b/src/app.scss
@@ -245,8 +245,6 @@ $modal-background-background-color-dark: rgba($dark, 0.86) !default; // remove t
   }
 }
 
-
-
 /* Loading chat messages */
 .is-loading {
   opacity: 0.5;
@@ -461,6 +459,10 @@ aside.menu.main-menu .menu-expanse {
 
   .control.send .button {
     width: 60px;
+  }
+  textarea {
+    max-height: calc(100vh - (var(--chatContentPaddingBottom) + var(--runningTotalLineHeight) * var(--running-totals))) !important;
+    min-height: 38px !important;
   }
 }
 

--- a/src/lib/ApiUtil.svelte
+++ b/src/lib/ApiUtil.svelte
@@ -2,9 +2,11 @@
   // This makes it possible to override the OpenAI API base URL in the .env file
   const apiBase = import.meta.env.VITE_API_BASE || 'https://api.openai.com'
   const endpointCompletions = import.meta.env.VITE_ENDPOINT_COMPLETIONS || '/v1/chat/completions'
+  const endpointGenerations = import.meta.env.VITE_ENDPOINT_GENERATIONS || '/v1/images/generations'
   const endpointModels = import.meta.env.VITE_ENDPOINT_MODELS || '/v1/models'
 
   export const getApiBase = ():string => apiBase
   export const getEndpointCompletions = ():string => endpointCompletions
+  export const getEndpointGenerations = ():string => endpointGenerations
   export const getEndpointModels = ():string => endpointModels
 </script>

--- a/src/lib/Export.svelte
+++ b/src/lib/Export.svelte
@@ -1,8 +1,9 @@
 <script context="module" lang="ts">
   import { get } from 'svelte/store'
   import type { Chat } from './Types.svelte'
-  import { chatsStorage } from './Storage.svelte'
+  import { chatsStorage, getChat } from './Storage.svelte'
   import { getExcludeFromProfile } from './Settings.svelte'
+  import { getImage } from './ImageStore.svelte'
 
   export const exportAsMarkdown = (chatId: number) => {
     const chats = get(chatsStorage)
@@ -27,9 +28,13 @@
     document.body.removeChild(a)
   }
 
-  export const exportChatAsJSON = (chatId: number) => {
-    const chats = get(chatsStorage)
-    const chat = chats.find((chat) => chat.id === chatId) as Chat
+  export const exportChatAsJSON = async (chatId: number) => {
+    const chat = JSON.parse(JSON.stringify(getChat(chatId))) as Chat
+    for (let i = 0; i < chat.messages.length; i++) {
+      // Pull images out of indexedDB store for JSON download
+      const m = chat.messages[i]
+      if (m.image) m.image = await getImage(m.image.id)
+    }
     const exportContent = JSON.stringify(chat)
     const blob = new Blob([exportContent], { type: 'text/json' })
     const url = URL.createObjectURL(blob)

--- a/src/lib/ImageStore.svelte
+++ b/src/lib/ImageStore.svelte
@@ -1,0 +1,71 @@
+<script context="module" lang="ts">
+  import Dexie, { type Table } from 'dexie'
+  import type { ChatImage } from './Types.svelte'
+  import { v4 as uuidv4 } from 'uuid'
+
+  let _hasIndexedDb = !!window.indexedDB
+  const dbCheck = _hasIndexedDb && window.indexedDB.open('test')
+  if (_hasIndexedDb) dbCheck.onerror = () => { _hasIndexedDb = false }
+  
+  const imageCache: Record<string, ChatImage> = {}
+
+  class ChatImageStore extends Dexie {
+    images!: Table<ChatImage>
+    constructor () {
+      super('chatImageStore')
+      this.version(1).stores({
+        images: 'id' // Primary key and indexed props
+      })
+    }
+  }
+
+  const imageDb = new ChatImageStore()
+
+  export const hasIndexedDb = () => _hasIndexedDb
+
+  export const getImage = async (uuid:string): Promise<ChatImage> => {
+    let image = imageCache[uuid]
+    if (image || !_hasIndexedDb) return image
+    image = await imageDb.images.get(uuid) as any
+    imageCache[uuid] = image
+    return image
+  }
+
+  export const deleteImage = async (chatId:number, uuid:string): Promise<void> => {
+    const cached = imageCache[uuid]
+    if (cached) cached.chats = cached.chats?.filter(c => c !== chatId)
+    if (!cached?.chats?.length) delete imageCache[uuid]
+    if (_hasIndexedDb) {
+      const stored:ChatImage = await imageDb.images.get({ id: uuid }) as any
+      if (stored) stored.chats = stored.chats?.filter(c => c !== chatId)
+      if (!stored?.chats?.length) {
+        imageDb.images.delete(uuid)
+      } else if (stored) {
+        await setImage(chatId, stored)
+      }
+    }
+  }
+
+  export const setImage = async (chatId:number, image:ChatImage): Promise<ChatImage> => {
+    image.id = image.id || uuidv4()
+    let current: ChatImage
+    if (_hasIndexedDb) {
+      current = await imageDb.images.get({ id: image.id }) as any
+    } else {
+      current = imageCache[image.id]
+    }
+    current = current || image
+    current.chats = current.chats || []
+    if (!(chatId in current.chats)) current.chats.push(chatId)
+    imageCache[current.id] = current
+    if (_hasIndexedDb) {
+      imageDb.images.put(current, current.id)
+    }
+    const clone = JSON.parse(JSON.stringify(current))
+    // Return a copy without the payload so local storage doesn't get clobbered
+    delete clone.b64image
+    delete clone.chats
+    return clone
+  }
+
+</script>

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -14,10 +14,20 @@ const modelDetails : Record<string, ModelDetail> = {
         completion: 0.00006, // $0.06 per 1000 tokens completion
         max: 8192 // 8k max token buffer
       },
+      'gpt-3.5-turbo-0613': {
+        prompt: 0.0000015, // $0.0015 per 1000 tokens prompt
+        completion: 0.0000015, // $0.0015 per 1000 tokens completion
+        max: 4096 // 4k max token buffer
+      },
       'gpt-3.5': {
         prompt: 0.000002, // $0.002 per 1000 tokens prompt
         completion: 0.000002, // $0.002 per 1000 tokens completion
         max: 4096 // 4k max token buffer
+      },
+      'gpt-3.5-turbo-16k': {
+        prompt: 0.000003, // $0.003 per 1000 tokens prompt
+        completion: 0.000004, // $0.004 per 1000 tokens completion
+        max: 16384 // 16k max token buffer
       }
 }
 
@@ -35,7 +45,9 @@ export const supportedModels : Record<string, ModelDetail> = {
       'gpt-4-32k': modelDetails['gpt-4-32k'],
       'gpt-4-32k-0314': modelDetails['gpt-4-32k'],
       'gpt-3.5-turbo': modelDetails['gpt-3.5'],
-      'gpt-3.5-turbo-0301': modelDetails['gpt-3.5']
+      'gpt-3.5-turbo-16k': modelDetails['gpt-3.5-turbo-16k'],
+      'gpt-3.5-turbo-0301': modelDetails['gpt-3.5'],
+      'gpt-3.5-turbo-0613': modelDetails['gpt-3.5-turbo-0613']
 }
 
 const lookupList = {

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -31,6 +31,24 @@ const modelDetails : Record<string, ModelDetail> = {
       }
 }
 
+const imageModels : Record<string, ModelDetail> = {
+      'dall-e-1024x1024': {
+        prompt: 0.00,
+        completion: 0.020, // $0.020 per image
+        max: 1000 // 1000 char prompt, max
+      },
+      'dall-e-512x512': {
+        prompt: 0.00,
+        completion: 0.018, // $0.018 per image
+        max: 1000 // 1000 char prompt, max
+      },
+      'dall-e-256x256': {
+        prompt: 0.00,
+        completion: 0.016, // $0.016 per image
+        max: 1000 // 1000 char prompt, max
+      }
+}
+
 const unknownDetail = {
   prompt: 0,
   completion: 0,
@@ -51,11 +69,12 @@ export const supportedModels : Record<string, ModelDetail> = {
 }
 
 const lookupList = {
+  ...imageModels,
   ...modelDetails,
   ...supportedModels
 }
 
-export const supportedModelKeys = Object.keys(supportedModels)
+export const supportedModelKeys = Object.keys({ ...supportedModels, ...imageModels })
 
 const tpCache : Record<string, ModelDetail> = {}
 

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -86,6 +86,7 @@ const defaults:ChatSettings = {
   autoStartSession: false,
   trainingPrompts: [],
   hiddenPromptPrefix: '',
+  imageGenerationSize: '',
   // useResponseAlteration: false,
   // responseAlterations: [],
   isDirty: false
@@ -96,6 +97,12 @@ const excludeFromProfile = {
   user: true,
   isDirty: true
 }
+
+export const imageGenerationSizes = [
+  '1024x1024', '512x512', '256x256'
+]
+
+export const imageGenerationSizeTypes = ['', ...imageGenerationSizes]
 
 const profileSetting: ChatSetting & SettingSelect = {
       key: 'profile',
@@ -269,6 +276,18 @@ const summarySettings: ChatSetting[] = [
         placeholder: 'Enter a prompt that will be used to summarize past prompts here.',
         type: 'textarea',
         hide: (chatId) => getChatSettings(chatId).continuousChat !== 'summary'
+      },
+      {
+        key: 'imageGenerationSize',
+        name: 'Image Generation Size',
+        header: 'Image Generation',
+        headerClass: 'is-info',
+        title: 'Prompt an image with: show me an image of ...',
+        type: 'select',
+        options: [
+          { value: '', text: 'OFF - Disable Image Generation' },
+          ...imageGenerationSizes.map(s => { return { value: s, text: s } })
+        ]
       }
 ]
 

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -1,7 +1,10 @@
 <script context="module" lang="ts">
-  import type { supportedModelKeys } from './Models.svelte'
+  import { supportedModelKeys } from './Models.svelte'
+  import { imageGenerationSizeTypes } from './Settings.svelte'
 
   export type Model = typeof supportedModelKeys[number];
+
+  export type ImageGenerationSizes = typeof imageGenerationSizeTypes[number];
 
   export type ModelDetail = {
     prompt: number;
@@ -15,8 +18,14 @@
     total_tokens: number;
   };
 
+  export interface ChatImage {
+    id: string;
+    b64image: string;
+    chats: number[];
+  }
+
   export type Message = {
-    role: 'user' | 'assistant' | 'system' | 'error';
+    role: 'user' | 'assistant' | 'system' | 'error' | 'image';
     content: string;
     uuid: string;
     usage?: Usage;
@@ -27,12 +36,30 @@
     suppress?: boolean;
     finish_reason?: string;
     streaming?: boolean;
+    image?: ChatImage;
   };
 
   export type ResponseAlteration = {
     type: 'prompt' | 'replace';
     match: string;
     replace: string;
+  }
+
+  export type ResponseImageDetail = {
+    url: string;
+    b64_json: string;
+  }
+
+  export type ResponseImage = {
+    created: number;
+    data: ResponseImageDetail[];
+  }
+
+  export type RequestImageGeneration = {
+    prompt: string;
+    n?: number;
+    size?: ImageGenerationSizes;
+    response_format?: keyof ResponseImageDetail;
   }
 
   export type Request = {
@@ -66,6 +93,7 @@
     systemPrompt: string;
     autoStartSession: boolean;
     hiddenPromptPrefix: string;
+    imageGenerationSize: ImageGenerationSizes;
     trainingPrompts?: Message[];
     useResponseAlteration?: boolean;
     responseAlterations?: ResponseAlteration[];

--- a/src/lib/Util.svelte
+++ b/src/lib/Util.svelte
@@ -21,6 +21,13 @@
     const anyEl = el as any // Oh how I hate typescript.  All the markup of Java with no real payoff..
     if (!anyEl.__didAutoGrow) el.style.height = '38px' // don't use "auto" here.  Firefox will over-size.
     el.style.height = el.scrollHeight + 'px'
+    setTimeout(() => {
+      if (el.scrollHeight > el.getBoundingClientRect().height + 5) {
+        el.style.overflowY = 'auto'
+      } else {
+        el.style.overflowY = ''
+      }
+    }, 0)
     anyEl.__didAutoGrow = true // don't resize this one again unless it's via an event
   }
 


### PR DESCRIPTION
- Added DALL-E images generation.  Once enabled, you can prompt: "show me an image of a monkey eating popcorn" and it will direct the prompt "a monkey eating popcorn" to the image generation endpoint.
- Added new gpt-3.5-turbo-16k and gpt-3.5-turbo-0613 models, per #171.  (token cost for base gpt-3.5-turbo model will need to be updated after the 27th.)
- Fixed textarea issues from #172

https://webifi.github.io/ChatGPT-Web-Updated-UI/
