### PR TITLE
update token cost, add 0613 models for gpt-4

### DIFF
--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -16,7 +16,7 @@ const modelDetails : Record<string, ModelDetail> = {
       },
       'gpt-3.5-turbo-0613': {
         prompt: 0.0000015, // $0.0015 per 1000 tokens prompt
-        completion: 0.0000015, // $0.0015 per 1000 tokens completion
+        completion: 0.000002, // $0.002 per 1000 tokens completion
         max: 4096 // 4k max token buffer
       },
       'gpt-3.5': {
@@ -60,8 +60,10 @@ const unknownDetail = {
 export const supportedModels : Record<string, ModelDetail> = {
       'gpt-4': modelDetails['gpt-4'],
       'gpt-4-0314': modelDetails['gpt-4'],
+      'gpt-4-0613': modelDetails['gpt-4'],
       'gpt-4-32k': modelDetails['gpt-4-32k'],
       'gpt-4-32k-0314': modelDetails['gpt-4-32k'],
+      'gpt-4-32k-0613': modelDetails['gpt-4-32k'],
       'gpt-3.5-turbo': modelDetails['gpt-3.5'],
       'gpt-3.5-turbo-16k': modelDetails['gpt-3.5-turbo-16k'],
       'gpt-3.5-turbo-0301': modelDetails['gpt-3.5'],


### PR DESCRIPTION
update token cost, add 0613 models for gpt-4

(Eventually I'll update the model request to pull down new gpt-3 and gpt-4 models automatically, though there doesn't seem to be anywhere to get updated pricing.)