### PR TITLE
Fix delete all chats option and code highlighting while streaming #178

### DIFF
--- a/src/lib/ChatOptionMenu.svelte
+++ b/src/lib/ChatOptionMenu.svelte
@@ -74,6 +74,7 @@
   }
 
   const confirmClearChats = () => {
+    if (!sortedChats.length) return
     close()
     openModal(PromptConfirm, {
       title: 'Delete ALL Chat',
@@ -148,7 +149,7 @@
       <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { if (chatId) close(); delChat() }}>
         <span class="menu-icon"><Fa icon={faTrash}/></span> Delete Chat
       </a>
-      <a href={'#'} class="dropdown-item" on:click|preventDefault={() => { if (chatId) confirmClearChats() }}>
+      <a href={'#'} class="dropdown-item" class:is-disabled={$chatsStorage && !$chatsStorage[0]} on:click|preventDefault={() => { confirmClearChats() }}>
         <span class="menu-icon"><Fa icon={faTrashCan}/></span> Delete ALL Chats
       </a>
       <hr class="dropdown-divider">

--- a/src/lib/EditMessage.svelte
+++ b/src/lib/EditMessage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Code from './Code.svelte'
-  import { createEventDispatcher, onMount } from 'svelte'
+  import { afterUpdate, createEventDispatcher, onMount } from 'svelte'
   import { deleteMessage, chatsStorage, deleteSummaryMessage, truncateFromMessage, submitExitingPromptsNow, saveChatStore, continueMessage } from './Storage.svelte'
   import { getPrice } from './Stats.svelte'
   import SvelteMarkdown from 'svelte-markdown'
@@ -37,6 +37,7 @@
   let original:string
   let defaultModel:Model
   let imageUrl:string
+  let refreshCounter = 0
 
   onMount(() => {
     defaultModel = chatSettings.model
@@ -45,6 +46,10 @@
         imageUrl = 'data:image/png;base64, ' + i.b64image
       })
     }
+  })
+
+  afterUpdate(() => {
+    if (message.content.slice(-5).match(/```/)) refreshCounter++
   })
 
   const edit = () => {
@@ -224,11 +229,13 @@
         {#if message.summary && !message.summary.length}
         <p><b>Summarizing...</b></p>
         {/if}
+        {#key refreshCounter}
         <SvelteMarkdown 
           source={message.content} 
           options={markdownOptions} 
           renderers={{ code: Code, html: Code }}
         />
+        {/key}
         {#if imageUrl}
           <img src={imageUrl} alt="">
         {/if}

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -47,7 +47,7 @@
             ></div>
           {:else}
           <div class="level-item">
-            <button on:click={() => { startNewChatWithWarning(activeChatId) }} class="panel-block button" title="Start new chat with default profile" class:is-disabled={!$apiKeyStorage}
+            <button on:click={() => { $pinMainMenu = false; startNewChatWithWarning(activeChatId) }} class="panel-block button" title="Start new chat with default profile" class:is-disabled={!$apiKeyStorage}
               ><span class="greyscale mr-2"><Fa icon={faSquarePlus} /></span> New chat</button>
             </div>
           {/if}


### PR DESCRIPTION
- Check the last few characters of the updated content for ``` and refresh the sveltemarkdown component to get code highlighting working #178
- Allow delete all chats menu option to work when not in a chat
