### PR TITLE
Fix scroll jumping in settings dialog

### DIFF
--- a/src/lib/ChatSettingField.svelte
+++ b/src/lib/ChatSettingField.svelte
@@ -8,14 +8,25 @@
   import Fa from 'svelte-fa/src/fa.svelte'
   import { openModal } from 'svelte-modals'
   import PromptConfirm from './PromptConfirm.svelte'
+  import { afterUpdate, onMount } from 'svelte'
 
   export let setting:ChatSetting
   export let chatSettings:ChatSettings
   export let chat:Chat
   export let chatDefaults:Record<string, any>
   export let originalProfile:String
+  export let rkey:number = 0
 
   const chatId = chat.id
+  let show = false
+
+  onMount(() => {
+    show = (typeof setting.hide !== 'function') || !setting.hide(chatId)
+  })
+
+  afterUpdate(() => {
+    show = (typeof setting.hide !== 'function') || !setting.hide(chatId)
+  })
 
   const fieldControls:ControlAction[] = (setting.fieldControls || [] as FieldControl[]).map(fc => {
     return fc.getAction(chatId, setting, chatSettings[setting.key])
@@ -124,7 +135,7 @@
 
 </script>
 
-{#if (typeof setting.hide !== 'function') || !setting.hide(chatId)}
+{#if show}
   {#if setting.header}
   <p class="notification {setting.headerClass}">
     {@html setting.header}
@@ -180,11 +191,13 @@
         {:else if setting.type === 'select' || setting.type === 'select-number'}
           <!-- <div class="select"> -->
             <div class="select" class:control={fieldControls.length}>
+            {#key rkey}
             <select id="settings-{setting.key}" title="{setting.title}" on:change={e => queueSettingValueChange(e, setting) } >
               {#each setting.options as option}
                 <option class:is-default={option.value === chatDefaults[setting.key]} value={option.value} selected={option.value === chatSettings[setting.key]}>{option.text}</option>
               {/each}
             </select>
+            {/key}
             </div>
             {#each fieldControls as cont}
             <div class="control">

--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -282,11 +282,11 @@
       <button class="delete" aria-label="close" on:click={closeSettings}></button>
     </header>
     <section class="modal-card-body">
-      {#key showSettingsModal}
       {#each settingsList as setting}
-        <ChatSettingField on:refresh={refreshSettings} on:change={setDirty} chat={chat} chatDefaults={chatDefaults} chatSettings={chatSettings} setting={setting} originalProfile={originalProfile} />
+      <!-- {#key showSettingsModal} -->
+        <ChatSettingField rkey={showSettingsModal} on:refresh={refreshSettings} on:change={setDirty} chat={chat} chatDefaults={chatDefaults} chatSettings={chatSettings} setting={setting} originalProfile={originalProfile} />
+      <!-- {/key} -->
       {/each}
-      {/key}
     </section>
 
     <footer class="modal-card-foot">

--- a/src/lib/EditMessage.svelte
+++ b/src/lib/EditMessage.svelte
@@ -49,7 +49,7 @@
   })
 
   afterUpdate(() => {
-    if (message.content.slice(-5).match(/```/)) refreshCounter++
+    if (message.content.slice(-5).includes('```')) refreshCounter++
   })
 
   const edit = () => {


### PR DESCRIPTION
- When changing some setting in the chat settings dialog/modal, the scroll bar could jump around. This tries to fix that as much as possible.
- Use the faster includes instead of match when checking to update code highlighting.