### PR TITLE
Add "apply prompt" option, clarify the "new chat" buttons in settings, fix potential memory leak

### DIFF
--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { applyProfile, getDefaultProfileKey, getProfile, getProfileSelect } from './Profiles.svelte'
+  import { applyProfile, getDefaultProfileKey, getProfile, getProfileSelect, setSystemPrompt } from './Profiles.svelte'
   import { getChatDefaults, getChatSettingList, getChatSettingObjectByKey, getExcludeFromProfile } from './Settings.svelte'
   import {
     saveChatStore,
@@ -25,9 +25,8 @@
     faDownload,
     faUpload,
     faSquarePlus,
-
-    faRotateLeft
-
+    faRotateLeft,
+    faCheckCircle
   } from '@fortawesome/free-solid-svg-icons/index'
   import { exportProfileAsJSON } from './Export.svelte'
   import { onMount, afterUpdate } from 'svelte'
@@ -271,6 +270,12 @@
     chatSettings.isDirty = !deepEqual(profile, chatSettings)
   }
 
+  const applyToChat = () => {
+    if (chatSettings.useSystemPrompt) {
+      setSystemPrompt(chatId)
+    }
+  }
+
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -321,6 +326,9 @@
                 </a>
                 <a href={'#'} class="dropdown-item" on:click|preventDefault={startNewChat}>
                   <span class="menu-icon"><Fa icon={faSquarePlus}/></span> Start New Chat Using Profile
+                </a>
+                <a href={'#'} class="dropdown-item" on:click|preventDefault={applyToChat}>
+                  <span class="menu-icon"><Fa icon={faCheckCircle}/></span> Apply Prompts to Current Chat
                 </a>
                 <hr class="dropdown-divider">
                 <a href={'#'} 

--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -300,7 +300,7 @@
           <!-- <button class="button is-info" on:click={closeSettings}>Close</button> -->
           <button class="button" title="Save changes to this profile." class:is-disabled={!chatSettings.isDirty} on:click={saveProfile}>Save</button>    
           <button class="button is-warning" title="Throw away changes to this profile." class:is-disabled={!chatSettings.isDirty} on:click={clearSettings}>Reset</button>
-          <button class="button" title="Start new chat with this profile." on:click={startNewChat}>New Chat</button>
+          <button class="button" title="Start new chat with this profile." on:click={startNewChat}>New Chat <span class="is-hidden-mobile">&nbsp;from Current</span></button>
         </div>
         <div class="level-right">
           <div class="dropdown is-right is-up" class:is-active={showProfileMenu}>
@@ -325,7 +325,7 @@
                   <span class="menu-icon"><Fa icon={faThumbtack}/></span> Set as Default Profile
                 </a>
                 <a href={'#'} class="dropdown-item" on:click|preventDefault={startNewChat}>
-                  <span class="menu-icon"><Fa icon={faSquarePlus}/></span> Start New Chat Using Profile
+                  <span class="menu-icon"><Fa icon={faSquarePlus}/></span> Start New Chat from Current
                 </a>
                 <a href={'#'} class="dropdown-item" on:click|preventDefault={applyToChat}>
                   <span class="menu-icon"><Fa icon={faCheckCircle}/></span> Apply Prompts to Current Chat


### PR DESCRIPTION
- Add option to the chat settings ... menu to apply the system prompt of the current settings to the current chat.
- Clarify that the "New Chat" options in the settings modal will create a new chat using the current settings.
- Fix a memory leak in how the abort handler was being used, and a bug in how it was implemented for aborting image generation requests.
