### PR TITLE
Fix restore chat JSON regression, Fix issue with summary continuation 

### DIFF
--- a/src/lib/Storage.svelte
+++ b/src/lib/Storage.svelte
@@ -351,7 +351,7 @@
   }
 
   export const updateChatImages = async (chatId: number, chat: Chat) => {
-    const messages = getMessages(chatId)
+    const messages = chat.messages
     for (let i = 0; i < messages.length; i++) {
       const m = messages[i]
       if (m.image) m.image = await setImage(chatId, m.image)

--- a/src/lib/Storage.svelte
+++ b/src/lib/Storage.svelte
@@ -245,7 +245,7 @@
       setMessagesTimer = setTimeout(() => {
         getChat(chatId).messages = messages
         saveChatStore()
-      }, 100)
+      }, 200)
     } else {
       getChat(chatId).messages = messages
       saveChatStore()


### PR DESCRIPTION
- Broke chat JSON restore while implementing smooth streaming/message cache.  Fixed.
- Summarization continuation wasn't working correctly.  Fixed.
- Increased message cache save inactivity threshold from 100ms to 200ms.