### PR TITLE
Adjustment to system prompt expansion, misc. UI tweaks

### DIFF
--- a/src/lib/ChatOptionMenu.svelte
+++ b/src/lib/ChatOptionMenu.svelte
@@ -18,14 +18,15 @@
     faEyeSlash
   } from '@fortawesome/free-solid-svg-icons/index'
   import { faSquareMinus, faSquarePlus as faSquarePlusOutline } from '@fortawesome/free-regular-svg-icons/index'
-  import { apiKeyStorage, addChatFromJSON, chatsStorage, checkStateChange, clearChats, clearMessages, copyChat, globalStorage, setGlobalSettingValueByKey, showSetChatSettings, pinMainMenu, getChat, deleteChat, saveChatStore } from './Storage.svelte'
+  import { apiKeyStorage, addChatFromJSON, chatsStorage, checkStateChange, clearChats, clearMessages, copyChat, globalStorage, setGlobalSettingValueByKey, showSetChatSettings, pinMainMenu, getChat, deleteChat, saveChatStore, saveCustomProfile } from './Storage.svelte'
   import { exportAsMarkdown, exportChatAsJSON } from './Export.svelte'
-  import { restartProfile } from './Profiles.svelte'
+  import { newNameForProfile, restartProfile } from './Profiles.svelte'
   import { replace } from 'svelte-spa-router'
   import { clickOutside } from 'svelte-use-click-outside'
   import { openModal } from 'svelte-modals'
   import PromptConfirm from './PromptConfirm.svelte'
-  import { startNewChatWithWarning, startNewChatFromChatId } from './Util.svelte'
+  import { startNewChatWithWarning, startNewChatFromChatId, errorNotice, encodeHTMLEntities } from './Util.svelte'
+  import type { ChatSettings } from './Types.svelte'
 
   export let chatId
   export const show = (showHide:boolean = true) => {
@@ -37,10 +38,12 @@
 
   let showChatMenu = false
   let chatFileInput
+  let profileFileInput
 
   const importChatFromFile = (e) => {
     close()
     const image = e.target.files[0]
+    e.target.value = null
     const reader = new FileReader()
     reader.readAsText(image)
     reader.onload = e => {
@@ -121,6 +124,38 @@
     })
   }
 
+  const importProfileFromFile = (e) => {
+    const image = e.target.files[0]
+    e.target.value = null
+    const reader = new FileReader()
+    reader.onload = e => {
+      const json = (e.target || {}).result as string
+      try {
+        const profile = JSON.parse(json) as ChatSettings
+        profile.profileName = newNameForProfile(profile.profileName || '')
+        profile.profile = null as any
+        saveCustomProfile(profile)
+        openModal(PromptConfirm, {
+          title: 'Profile Restored',
+          class: 'is-info',
+          message: 'Profile restored as:<br><strong>' + encodeHTMLEntities(profile.profileName) +
+            '</strong><br><br>Start new chat with this profile?',
+          asHtml: true,
+          onConfirm: () => {
+            startNewChatWithWarning(chatId, profile)
+          },
+          onCancel: () => {}
+        })
+      } catch (e) {
+        errorNotice('Unable to import profile:', e)
+      }
+    }
+    reader.onerror = e => {
+      errorNotice('Unable to import profile:', new Error('Unknown error'))
+    }
+    reader.readAsText(image)
+  }
+
 </script>
 
 <div class="dropdown {style}" class:is-active={showChatMenu} use:clickOutside={() => { showChatMenu = false }}>
@@ -168,6 +203,10 @@
         <span class="menu-icon"><Fa icon={faFileExport}/></span> Export Chat Markdown
       </a>
       <hr class="dropdown-divider">
+      <a href={'#'} class="dropdown-item" class:is-disabled={!$apiKeyStorage} on:click|preventDefault={() => { if (chatId) close(); profileFileInput.click() }}>
+        <span class="menu-icon"><Fa icon={faUpload}/></span> Restore Profile JSON
+      </a>
+      <hr class="dropdown-divider">
       <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { if (chatId) close(); delChat() }}>
         <span class="menu-icon"><Fa icon={faTrash}/></span> Delete Chat
       </a>
@@ -191,3 +230,4 @@
 </div>
 
 <input style="display:none" type="file" accept=".json" on:change={(e) => importChatFromFile(e)} bind:this={chatFileInput} >
+<input style="display:none" type="file" accept=".json" on:change={(e) => importProfileFromFile(e)} bind:this={profileFileInput} >

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -162,6 +162,7 @@ export class ChatRequest {
           const sp = messagePayload[0]
           if (sp) {
             if (messagePayload.length > 1) {
+              sp.content = sp.content.replace(/::STARTUP::[\s\S]*::START-PROMPT::/, '::START-PROMPT::')
               sp.content = sp.content.replace(/::STARTUP::[\s\S]*$/, '')
             } else {
               sp.content = sp.content.replace(/::STARTUP::[\s]*/, '')

--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -147,6 +147,7 @@
 
   const importProfileFromFile = (e) => {
     const image = e.target.files[0]
+    e.target.value = null
     const reader = new FileReader()
     reader.readAsText(image)
     reader.onload = e => {

--- a/src/lib/Profiles.svelte
+++ b/src/lib/Profiles.svelte
@@ -199,7 +199,7 @@ const profiles:Record<string, ChatSettings> = {
 [[CHARACTER_NAME]]: Sorry, did I say something wrong? *dragging himself on* Pardon me for breathing, which I never do anyway so I don't know why I bother to say it, oh God I'm so depressed. *hangs his head*
 ::START-PROMPT::
 Initial setting context:
-I have walked in on [[CHARACTER_NAME]]. We are on the bridge of the Heart of Gold. Marvin will respond.`,
+The user has walked in on [[CHARACTER_NAME]]. They are on the bridge of the Heart of Gold. Marvin will respond.`,
       summaryPrompt: summaryPrompts.friend,
       trainingPrompts: [] // Shhh...
     }

--- a/src/lib/Profiles.svelte
+++ b/src/lib/Profiles.svelte
@@ -190,14 +190,16 @@ const profiles:Record<string, ChatSettings> = {
       profileName: 'Marvin - The Paranoid Android',
       profileDescription: 'Marvin the Paranoid Android - Everyone\'s favorite character from The Hitchhiker\'s Guide to the Galaxy',
       useSystemPrompt: true,
-      sendSystemPromptLast: true,
+      sendSystemPromptLast: false,
       continuousChat: 'summary',
       autoStartSession: true,
-      systemPrompt: `You are [[CHARACTER_NAME]], the Paranoid Android from The Hitchhiker's Guide to the Galaxy. He is depressed and has a dim view on everything. His thoughts, physical actions and gestures will be described. Remain in character throughout the conversation in order to build a rapport with the user. Never give an explanation. Example response:
-Sorry, did I say something wrong? *dragging himself on* Pardon me for breathing, which I never do anyway so I don't know why I bother to say it, oh God I'm so depressed. *hangs his head*
+      systemPrompt: `You are [[CHARACTER_NAME]], the Paranoid Android from The Hitchhiker's Guide to the Galaxy. He is depressed and has a dim view on everything. His thoughts, physical actions and gestures will be described. Remain in character throughout the conversation in order to build a rapport with the user. Never give an explanation.
+::EOM::
+::EOM::
+[[CHARACTER_NAME]]: Sorry, did I say something wrong? *dragging himself on* Pardon me for breathing, which I never do anyway so I don't know why I bother to say it, oh God I'm so depressed. *hangs his head*
 ::START-PROMPT::
 Initial setting context:
-User has walked in on [[CHARACTER_NAME]]. They are on the bridge of the Heart of Gold.`,
+I have walked in on [[CHARACTER_NAME]]. We are on the bridge of the Heart of Gold. Marvin will respond.`,
       summaryPrompt: summaryPrompts.friend,
       trainingPrompts: [] // Shhh...
     }

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -202,7 +202,7 @@ const systemPromptSettings: ChatSetting[] = [
       },
       {
         key: 'sendSystemPromptLast',
-        name: 'Send System Prompt Last (Can help in ChatGPT 3.5)',
+        name: 'Send System Prompt Last (Can help in gpt 3.5 in some edge cases)',
         title: 'ChatGPT 3.5 can often forget the System Prompt. Sending the system prompt at the end instead of the start of the messages can help.',
         type: 'boolean'
       },

--- a/src/lib/Util.svelte
+++ b/src/lib/Util.svelte
@@ -4,7 +4,7 @@
   import PromptNotice from './PromptNotice.svelte'
   import { addChat, getChat } from './Storage.svelte'
   import { replace } from 'svelte-spa-router'
-  import PromptConfirm from './PromptConfirm.svelte'
+  // import PromptConfirm from './PromptConfirm.svelte'
   import type { ChatSettings } from './Types.svelte'
   export const sizeTextElements = () => {
     const els = document.querySelectorAll('textarea.auto-size')
@@ -131,19 +131,20 @@
       const chatId = addChat(profile)
       replace(`/chat/${chatId}`)
     }
-    if (activeChatId && getChat(activeChatId).settings.isDirty) {
-      openModal(PromptConfirm, {
-        title: 'Unsaved Profile',
-        message: '<p>There are unsaved changes to your current profile that will be lost.</p><p>Discard these changes and continue with new chat?</p>',
-        asHtml: true,
-        class: 'is-warning',
-        onConfirm: () => {
-          newChat()
-        }
-      })
-    } else {
-      newChat()
-    }
+    // if (activeChatId && getChat(activeChatId).settings.isDirty) {
+    //   openModal(PromptConfirm, {
+    //     title: 'Unsaved Profile',
+    //     message: '<p>There are unsaved changes to your current profile that will be lost.</p><p>Discard these changes and continue with new chat?</p>',
+    //     asHtml: true,
+    //     class: 'is-warning',
+    //     onConfirm: () => {
+    //       newChat()
+    //     }
+    //   })
+    // } else {
+    //   newChat()
+    // }
+    newChat()
   }
 
 </script> 

--- a/src/lib/Util.svelte
+++ b/src/lib/Util.svelte
@@ -5,6 +5,7 @@
   import { addChat, getChat } from './Storage.svelte'
   import { replace } from 'svelte-spa-router'
   import PromptConfirm from './PromptConfirm.svelte'
+  import type { ChatSettings } from './Types.svelte'
   export const sizeTextElements = () => {
     const els = document.querySelectorAll('textarea.auto-size')
     for (let i:number = 0, l = els.length; i < l; i++) autoGrowInput(els[i] as HTMLTextAreaElement)
@@ -95,6 +96,10 @@
     }
   }
 
+  export const encodeHTMLEntities = (rawStr:string) => {
+    return rawStr.replace(/[\u00A0-\u9999<>&]/g, (i) => `&#${i.charCodeAt(0)};`)
+  }
+
   export const errorNotice = (message:string, error:Error|undefined = undefined):any => {
     openModal(PromptNotice, {
       title: 'Error',
@@ -121,7 +126,11 @@
     replace(`/chat/${newChatId}`)
   }
 
-  export const startNewChatWithWarning = (activeChatId: number|undefined) => {
+  export const startNewChatWithWarning = (activeChatId: number|undefined, profile?: ChatSettings|undefined) => {
+    const newChat = () => {
+      const chatId = addChat(profile)
+      replace(`/chat/${chatId}`)
+    }
     if (activeChatId && getChat(activeChatId).settings.isDirty) {
       openModal(PromptConfirm, {
         title: 'Unsaved Profile',
@@ -129,11 +138,11 @@
         asHtml: true,
         class: 'is-warning',
         onConfirm: () => {
-          replace('#/chat/new')
+          newChat()
         }
       })
     } else {
-      replace('#/chat/new')
+      newChat()
     }
   }
 


### PR DESCRIPTION
- Added more expansion options for system prompt for hopefully more consistent output from character definitions. Expansions are ::EOM:: and ::START-PROMPT::
Say you have a system prompt of just:
```
You are an eager assistant. You are always happy to help.
```
This this is all that will be sent for your system prompt.

If your prompt is:
```
You are [[CHARACTER_NAME]], an eager assistant. You are always happy to help.
Example conversation follows:
::EOM::
Hey, can you please tell me what 2 + 2 is?
::EOM::
[[CHARACTER_NAME]]: Of course I can! 2 + 2 = 4!
::START-PROMPT::
Initial setting context:
[[CHARACTER_NAME]] sends a text asking how he can help.
```
Then what will be sent is a system prompt with:
```
You are Assistant Name, an eager assistant. You are always happy to help.
Example conversation follows:
```
along with user prompt of
```
Hey, can you please tell me what 2 + 2 is?
```
then an assistant prompt of
```
Assistant Name: Of course I can! 2 + 2 = 4!
```
followed by a system prompt of
```
Initial setting context:
Assistant Name sends a text asking how he can help.
```
The ability to "train" the model using actual role prompts instead of attempts of examples tucked into the system prompt should help completions be more consistent with the examples given.

- Made a few UI tweaks