### PR TITLE
Experimental support for Petals/Llama 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-svelte3": "^4.0.0",
         "flourite": "^1.2.4",
         "gpt-tokenizer": "^2.0.0",
+        "llama-tokenizer-js": "^1.1.1",
         "postcss": "^8.4.26",
         "sass": "^1.63.6",
         "stacking-order": "^2.0.0",
@@ -3181,6 +3182,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/llama-tokenizer-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/llama-tokenizer-js/-/llama-tokenizer-js-1.1.1.tgz",
+      "integrity": "sha512-5H2oSJnSufWGhOw6hcCGAqJeB3POmeIBzRklH3cXs0L4MSAYdwoYTodni4j5YVo6jApdhaqaNVU66gNRgXeBRg==",
+      "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-svelte3": "^4.0.0",
     "flourite": "^1.2.4",
     "gpt-tokenizer": "^2.0.0",
+    "llama-tokenizer-js": "^1.1.1",
     "postcss": "^8.4.26",
     "sass": "^1.63.6",
     "stacking-order": "^2.0.0",

--- a/src/lib/ApiUtil.svelte
+++ b/src/lib/ApiUtil.svelte
@@ -5,12 +5,12 @@
   const endpointGenerations = import.meta.env.VITE_ENDPOINT_GENERATIONS || '/v1/images/generations'
   const endpointModels = import.meta.env.VITE_ENDPOINT_MODELS || '/v1/models'
   const endpointEmbeddings = import.meta.env.VITE_ENDPOINT_EMBEDDINGS || '/v1/embeddings'
-  const endpointPetalsV2Websocket = import.meta.env.VITE_PEDALS_WEBSOCKET || 'wss://chat.petals.dev/api/v2/generate'
+  const endpointPetals = import.meta.env.VITE_PEDALS_WEBSOCKET || 'wss://chat.petals.dev/api/v2/generate'
 
   export const getApiBase = ():string => apiBase
   export const getEndpointCompletions = ():string => endpointCompletions
   export const getEndpointGenerations = ():string => endpointGenerations
   export const getEndpointModels = ():string => endpointModels
   export const getEndpointEmbeddings = ():string => endpointEmbeddings
-  export const getPetalsV2Websocket = ():string => endpointPetalsV2Websocket
+  export const getPetals = ():string => endpointPetals
 </script>

--- a/src/lib/ApiUtil.svelte
+++ b/src/lib/ApiUtil.svelte
@@ -5,10 +5,12 @@
   const endpointGenerations = import.meta.env.VITE_ENDPOINT_GENERATIONS || '/v1/images/generations'
   const endpointModels = import.meta.env.VITE_ENDPOINT_MODELS || '/v1/models'
   const endpointEmbeddings = import.meta.env.VITE_ENDPOINT_EMBEDDINGS || '/v1/embeddings'
+  const endpointPetalsV2Websocket = import.meta.env.VITE_PEDALS_WEBSOCKET || 'wss://chat.petals.dev/api/v2/generate'
 
   export const getApiBase = ():string => apiBase
   export const getEndpointCompletions = ():string => endpointCompletions
   export const getEndpointGenerations = ():string => endpointGenerations
   export const getEndpointModels = ():string => endpointModels
   export const getEndpointEmbeddings = ():string => endpointEmbeddings
+  export const getPetalsV2Websocket = ():string => endpointPetalsV2Websocket
 </script>

--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -40,6 +40,7 @@
   import { openModal } from 'svelte-modals'
   import PromptInput from './PromptInput.svelte'
   import { ChatRequest } from './ChatRequest.svelte'
+  import { getModelDetail } from './Models.svelte'
 
   export let params = { chatId: '' }
   const chatId: number = parseInt(params.chatId)
@@ -423,7 +424,7 @@
   <div class="content has-text-centered running-total-container">
     {#each Object.entries(chat.usage || {}) as [model, usage]}
     <p class="is-size-7 running-totals">
-      <em>{model}</em> total <span class="has-text-weight-bold">{usage.total_tokens}</span>
+      <em>{getModelDetail(model || '').label || model}</em> total <span class="has-text-weight-bold">{usage.total_tokens}</span>
       tokens ~= <span class="has-text-weight-bold">${getPrice(usage, model).toFixed(6)}</span>
     </p>
     {/each}

--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -246,6 +246,19 @@
     chatRequest.updating = true
     chatRequest.updatingMessage = ''
 
+    let doScroll = true
+    let didScroll = false
+
+    const checkUserScroll = (e: Event) => {
+      const el = e.target as HTMLElement
+      if (el && e.isTrusted && didScroll) {
+        // from user
+        doScroll = (window.innerHeight + window.scrollY + 10) >= document.body.offsetHeight
+      }
+    }
+
+    window.addEventListener('scroll', checkUserScroll)
+
     try {
       const response = await chatRequest.sendRequest($currentChatMessages, {
         chat,
@@ -253,7 +266,8 @@
         streaming: chatSettings.stream,
         fillMessage,
         onMessageChange: (messages) => {
-          scrollToBottom(true)
+          if (doScroll) scrollToBottom(true)
+          didScroll = !!messages[0]?.content
         }
       })
       await response.promiseToFinish()
@@ -264,6 +278,8 @@
     } catch (e) {
       console.error(e)
     }
+  
+    window.removeEventListener('scroll', checkUserScroll)
 
     chatRequest.updating = false
     chatRequest.updatingMessage = ''

--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -273,12 +273,15 @@
   const suggestName = async (): Promise<void> => {
     const suggestMessage: Message = {
       role: 'user',
-      content: "Using appropriate language, please give a 5 word summary of this conversation's topic.",
+      content: "Using appropriate language, please tell me a short 6 word summary of this conversation's topic for use as a book title. Only respond with the summary.",
       uuid: uuidv4()
     }
 
     const suggestMessages = $currentChatMessages.slice(0, 10) // limit to first 10 messages
     suggestMessages.push(suggestMessage)
+
+    chatRequest.updating = true
+    chatRequest.updatingMessage = 'Getting suggestion for chat name...'
 
     const response = await chatRequest.sendRequest(suggestMessages, {
       chat,
@@ -297,7 +300,7 @@
       })
     } else {
       response.getMessages().forEach(m => {
-        const name = m.content.split(/\s+/).slice(0, 8).join(' ').trim()
+        const name = m.content.split(/\s+/).slice(0, 8).join(' ').replace(/^[^a-z0-9!?]+|[^a-z0-9!?]+$/gi, '').trim()
         if (name) chat.name = name
       })
       saveChatStore()

--- a/src/lib/ChatCompletionResponse.svelte
+++ b/src/lib/ChatCompletionResponse.svelte
@@ -175,15 +175,15 @@ export class ChatCompletionResponse {
       } as Message)
     }
     this.notifyMessageChange()
-    setTimeout(() => this.finish(), 250) // give others a chance to signal the finish first
+    setTimeout(() => this.finish(), 200) // give others a chance to signal the finish first
   }
 
   updateFromClose (force: boolean = false): void {
     if (!this.finished && !this.error && !this.messages?.find(m => m.content)) {
-      if (!force) return setTimeout(() => this.updateFromClose(true), 250) as any
-      return this.updateFromError('Unexpected connection termination')
+      if (!force) return setTimeout(() => this.updateFromClose(true), 300) as any
+      if (!this.finished) return this.updateFromError('Unexpected connection termination')
     }
-    setTimeout(() => this.finish(), 250) // give others a chance to signal the finish first
+    setTimeout(() => this.finish(), 260) // give others a chance to signal the finish first
   }
 
   onMessageChange = (listener: (m: Message[]) => void): number =>

--- a/src/lib/ChatCompletionResponse.svelte
+++ b/src/lib/ChatCompletionResponse.svelte
@@ -65,6 +65,10 @@ export class ChatCompletionResponse {
     this.promptTokenCount = tokens
   }
 
+  getPromptTokenCount (): number {
+    return this.promptTokenCount
+  }
+
   async updateImageFromSyncResponse (response: ResponseImage, prompt: string, model: Model) {
     this.setModel(model)
     for (let i = 0; i < response.data.length; i++) {

--- a/src/lib/ChatMenuItem.svelte
+++ b/src/lib/ChatMenuItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { replace } from 'svelte-spa-router'
   import type { Chat } from './Types.svelte'
-  import { apiKeyStorage, deleteChat, pinMainMenu, saveChatStore } from './Storage.svelte'
+  import { deleteChat, hasActiveModels, pinMainMenu, saveChatStore } from './Storage.svelte'
   import Fa from 'svelte-fa/src/fa.svelte'
   import { faTrash, faCircleCheck, faPencil } from '@fortawesome/free-solid-svg-icons/index'
   import { faMessage } from '@fortawesome/free-regular-svg-icons/index'
@@ -86,7 +86,7 @@
   <a 
     href={`#/chat/${chat.id}`}
     class="chat-menu-item"
-    class:is-waiting={waitingForConfirm} class:is-disabled={!$apiKeyStorage} class:is-active={activeChatId === chat.id}
+    class:is-waiting={waitingForConfirm} class:is-disabled={!hasActiveModels()} class:is-active={activeChatId === chat.id}
     on:click={() => { $pinMainMenu = false }} >
     {#if waitingForConfirm}
     <a class="is-pulled-right is-hidden px-1 py-0 has-text-weight-bold delete-button" href={'$'} on:click|preventDefault={() => delChat()}><Fa icon={faCircleCheck} /></a>

--- a/src/lib/ChatOptionMenu.svelte
+++ b/src/lib/ChatOptionMenu.svelte
@@ -18,7 +18,7 @@
     faEyeSlash
   } from '@fortawesome/free-solid-svg-icons/index'
   import { faSquareMinus, faSquarePlus as faSquarePlusOutline } from '@fortawesome/free-regular-svg-icons/index'
-  import { apiKeyStorage, addChatFromJSON, chatsStorage, checkStateChange, clearChats, clearMessages, copyChat, globalStorage, setGlobalSettingValueByKey, showSetChatSettings, pinMainMenu, getChat, deleteChat, saveChatStore, saveCustomProfile } from './Storage.svelte'
+  import { addChatFromJSON, chatsStorage, checkStateChange, clearChats, clearMessages, copyChat, globalStorage, setGlobalSettingValueByKey, showSetChatSettings, pinMainMenu, getChat, deleteChat, saveChatStore, saveCustomProfile, hasActiveModels } from './Storage.svelte'
   import { exportAsMarkdown, exportChatAsJSON } from './Export.svelte'
   import { newNameForProfile, restartProfile } from './Profiles.svelte'
   import { replace } from 'svelte-spa-router'
@@ -173,7 +173,7 @@
         <span class="menu-icon"><Fa icon={faGear}/></span> Chat Profile Settings
       </a>
       <hr class="dropdown-divider">
-      <a href={'#'} class:is-disabled={!$apiKeyStorage} on:click|preventDefault={() => { $apiKeyStorage && close(); $apiKeyStorage && startNewChatWithWarning(chatId) }} class="dropdown-item">
+      <a href={'#'} class:is-disabled={!hasActiveModels()} on:click|preventDefault={() => { hasActiveModels() && close(); hasActiveModels() && startNewChatWithWarning(chatId) }} class="dropdown-item">
         <span class="menu-icon"><Fa icon={faSquarePlus}/></span> New Chat from Default
       </a>
       <a href={'#'} class:is-disabled={!chatId} on:click|preventDefault={() => { chatId && close(); chatId && startNewChatFromChatId(chatId) }} class="dropdown-item">
@@ -196,14 +196,14 @@
       <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { close(); exportChatAsJSON(chatId) }}>
         <span class="menu-icon"><Fa icon={faDownload}/></span> Backup Chat JSON
       </a>
-      <a href={'#'} class="dropdown-item" class:is-disabled={!$apiKeyStorage} on:click|preventDefault={() => { if (chatId) close(); chatFileInput.click() }}>
+      <a href={'#'} class="dropdown-item" class:is-disabled={!hasActiveModels()} on:click|preventDefault={() => { if (chatId) close(); chatFileInput.click() }}>
         <span class="menu-icon"><Fa icon={faUpload}/></span> Restore Chat JSON
       </a>
       <a href={'#'} class="dropdown-item" class:is-disabled={!chatId} on:click|preventDefault={() => { if (chatId) close(); exportAsMarkdown(chatId) }}>
         <span class="menu-icon"><Fa icon={faFileExport}/></span> Export Chat Markdown
       </a>
       <hr class="dropdown-divider">
-      <a href={'#'} class="dropdown-item" class:is-disabled={!$apiKeyStorage} on:click|preventDefault={() => { if (chatId) close(); profileFileInput.click() }}>
+      <a href={'#'} class="dropdown-item" class:is-disabled={!hasActiveModels()} on:click|preventDefault={() => { if (chatId) close(); profileFileInput.click() }}>
         <span class="menu-icon"><Fa icon={faUpload}/></span> Restore Profile JSON
       </a>
       <hr class="dropdown-divider">

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -301,7 +301,7 @@ export class ChatRequest {
             if (m.length) {
               if (m.match(/\[\[USER_PROMPT\]\]/)) {
                 injectedPrompt = true
-                m.replace(/\[\[USER_PROMPT\]\]/g, lastMessage.content)
+                m = m.replace(/\[\[USER_PROMPT\]\]/g, lastMessage.content)
               }
               a.push({ role: a.length % 2 === 0 ? 'user' : 'assistant', content: m } as Message)
             }

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -320,7 +320,7 @@ export class ChatRequest {
               lastMessage.skipOnce = true
             }
           }
-          if (injectedPrompt) results.pop()
+          if (injectedPrompt) messages.pop()
           return results
         }
         return []

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -5,7 +5,7 @@
     import type { Chat, ChatCompletionOpts, ChatSettings, Message, Model, Request, RequestImageGeneration } from './Types.svelte'
     import { deleteMessage, getChatSettingValueNullDefault, insertMessages, getApiKey, addError, currentChatMessages, getMessages, updateMessages, deleteSummaryMessage } from './Storage.svelte'
     import { scrollToBottom, scrollToMessage } from './Util.svelte'
-    import { getRequestSettingList, defaultModel } from './Settings.svelte'
+    import { getDefaultModel, getRequestSettingList } from './Settings.svelte'
     import { v4 as uuidv4 } from 'uuid'
     import { get } from 'svelte/store'
     import { getEndpoint, getModelDetail } from './Models.svelte'
@@ -26,6 +26,7 @@ export class ChatRequest {
 
       setChat (chat: Chat) {
         this.chat = chat
+        this.chat.settings.model = this.getModel()
       }
 
       getChat (): Chat {
@@ -283,7 +284,7 @@ export class ChatRequest {
       }
 
       getModel (): Model {
-        return this.chat.settings.model || defaultModel
+        return this.chat.settings.model || getDefaultModel()
       }
 
       private buildHiddenPromptPrefixMessages (messages: Message[], insert:boolean = false): Message[] {

--- a/src/lib/ChatRequestOpenAi.svelte
+++ b/src/lib/ChatRequestOpenAi.svelte
@@ -1,0 +1,100 @@
+<script context="module" lang="ts">
+    import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event-source'
+    import ChatCompletionResponse from './ChatCompletionResponse.svelte'
+    import ChatRequest from './ChatRequest.svelte'
+    import { getEndpoint } from './Models.svelte'
+    import { getApiKey } from './Storage.svelte'
+    import type { ChatCompletionOpts, Request } from './Types.svelte'
+
+export const runOpenAiCompletionRequest = async (
+  request: Request,
+  chatRequest: ChatRequest,
+  chatResponse: ChatCompletionResponse,
+  signal: AbortSignal,
+  opts: ChatCompletionOpts) => {
+    // OpenAI Request
+      const model = chatRequest.getModel()
+      const abortListener = (e:Event) => {
+        chatRequest.updating = false
+        chatRequest.updatingMessage = ''
+        chatResponse.updateFromError('User aborted request.')
+        chatRequest.removeEventListener('abort', abortListener)
+      }
+      signal.addEventListener('abort', abortListener)
+      const fetchOptions = {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${getApiKey()}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(request),
+        signal
+      }
+
+      if (opts.streaming) {
+      /**
+             * Streaming request/response
+             * We'll get the response a token at a time, as soon as they are ready
+            */
+        chatResponse.onFinish(() => {
+          chatRequest.updating = false
+          chatRequest.updatingMessage = ''
+        })
+        fetchEventSource(getEndpoint(model), {
+          ...fetchOptions,
+          openWhenHidden: true,
+          onmessage (ev) {
+          // Remove updating indicator
+            chatRequest.updating = 1 // hide indicator, but still signal we're updating
+            chatRequest.updatingMessage = ''
+            // console.log('ev.data', ev.data)
+            if (!chatResponse.hasFinished()) {
+              if (ev.data === '[DONE]') {
+              // ?? anything to do when "[DONE]"?
+              } else {
+                const data = JSON.parse(ev.data)
+                // console.log('data', data)
+                window.setTimeout(() => { chatResponse.updateFromAsyncResponse(data) }, 1)
+              }
+            }
+          },
+          onclose () {
+            chatRequest.updating = false
+            chatRequest.updatingMessage = ''
+            chatResponse.updateFromClose()
+          },
+          onerror (err) {
+            console.error(err)
+            throw err
+          },
+          async onopen (response) {
+            if (response.ok && response.headers.get('content-type') === EventStreamContentType) {
+            // everything's good
+            } else {
+            // client-side errors are usually non-retriable:
+              await chatRequest.handleError(response)
+            }
+          }
+        }).catch(err => {
+          chatRequest.updating = false
+          chatRequest.updatingMessage = ''
+          chatResponse.updateFromError(err.message)
+        })
+      } else {
+      /**
+             * Non-streaming request/response
+             * We'll get the response all at once, after a long delay
+             */
+        const response = await fetch(getEndpoint(model), fetchOptions)
+        if (!response.ok) {
+          await chatRequest.handleError(response)
+        } else {
+          const json = await response.json()
+          // Remove updating indicator
+          chatRequest.updating = false
+          chatRequest.updatingMessage = ''
+          chatResponse.updateFromSyncResponse(json)
+        }
+      }
+}
+</script>

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -49,6 +49,7 @@ export const runPetalsCompletionRequest = async (
           const response = JSON.parse(event.data)
           if (!response.ok) {
             const err = new Error('Error opening socket: ' + response.traceback)
+            chatResponse.updateFromError(err.message)
             console.error(err)
             throw err
           }
@@ -89,6 +90,7 @@ export const runPetalsCompletionRequest = async (
             if (!response.ok) {
               const err = new Error('Error in response: ' + response.traceback)
               console.error(err)
+              chatResponse.updateFromError(err.message)
               throw err
             }
             window.setTimeout(() => {

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -1,0 +1,126 @@
+<script context="module" lang="ts">
+    import ChatCompletionResponse from './ChatCompletionResponse.svelte'
+    import ChatRequest from './ChatRequest.svelte'
+    import { getEndpoint, getModelDetail, getRoleTag } from './Models.svelte'
+    import type { ChatCompletionOpts, Message, Request } from './Types.svelte'
+    import { getModelMaxTokens } from './Stats.svelte'
+    import { updateMessages } from './Storage.svelte'
+
+export const runPetalsCompletionRequest = async (
+  request: Request,
+  chatRequest: ChatRequest,
+  chatResponse: ChatCompletionResponse,
+  signal: AbortSignal,
+  opts: ChatCompletionOpts) => {
+      // Petals
+      const model = chatRequest.getModel()
+      const modelDetail = getModelDetail(model)
+      const ws = new WebSocket(getEndpoint(model))
+      const abortListener = (e:Event) => {
+        chatRequest.updating = false
+        chatRequest.updatingMessage = ''
+        chatResponse.updateFromError('User aborted request.')
+        signal.removeEventListener('abort', abortListener)
+        ws.close()
+      }
+      signal.addEventListener('abort', abortListener)
+      const startSequences = modelDetail.start || []
+      const startSequence = startSequences[0] || ''
+      const stopSequences = modelDetail.stop || ['###']
+      const stopSequencesC = stopSequences.slice()
+      const stopSequence = stopSequencesC.shift()
+      const maxTokens = getModelMaxTokens(model)
+      let maxLen = Math.min(opts.maxTokens || chatRequest.chat.max_tokens || maxTokens, maxTokens)
+      const promptTokenCount = chatResponse.getPromptTokenCount()
+      if (promptTokenCount > maxLen) {
+        maxLen = Math.min(maxLen + promptTokenCount, maxTokens)
+      }
+      chatResponse.onFinish(() => {
+        chatRequest.updating = false
+        chatRequest.updatingMessage = ''
+      })
+      ws.onopen = () => {
+        ws.send(JSON.stringify({
+          type: 'open_inference_session',
+          model,
+          max_length: maxLen
+        }))
+        ws.onmessage = event => {
+          const response = JSON.parse(event.data)
+          if (!response.ok) {
+            const err = new Error('Error opening socket: ' + response.traceback)
+            console.error(err)
+            throw err
+          }
+          const rMessages = request.messages || [] as Message[]
+          const inputArray = (rMessages).reduce((a, m) => {
+            const c = getRoleTag(m.role, model, chatRequest.chat) + m.content
+            a.push(c)
+            return a
+          }, [] as string[])
+          const lastMessage = rMessages[rMessages.length - 1]
+          if (lastMessage && lastMessage.role !== 'assistant') {
+            inputArray.push(getRoleTag('assistant', model, chatRequest.chat))
+          }
+          const petalsRequest = {
+            type: 'generate',
+            inputs: inputArray.join(stopSequence),
+            max_new_tokens: 3, // wait for up to 3 tokens before displaying
+            stop_sequence: stopSequence,
+            doSample: 1,
+            temperature: request.temperature || 0,
+            top_p: request.top_p || 0,
+            extra_stop_sequences: stopSequencesC
+          }
+          ws.send(JSON.stringify(petalsRequest))
+          ws.onmessage = event => {
+            // Remove updating indicator
+            chatRequest.updating = 1 // hide indicator, but still signal we're updating
+            chatRequest.updatingMessage = ''
+            const response = JSON.parse(event.data)
+            if (!response.ok) {
+              const err = new Error('Error in response: ' + response.traceback)
+              console.error(err)
+              throw err
+            }
+            window.setTimeout(() => {
+              chatResponse.updateFromAsyncResponse(
+                      {
+                        model,
+                        choices: [{
+                          delta: {
+                            content: response.outputs,
+                            role: 'assistant'
+                          },
+                          finish_reason: (response.stop ? 'stop' : null)
+                        }]
+                      } as any
+              )
+              if (response.stop) {
+                const message = chatResponse.getMessages()[0]
+                if (message) {
+                  for (let i = 0, l = stopSequences.length; i < l; i++) {
+                    if (message.content.endsWith(stopSequences[i])) {
+                      message.content = message.content.slice(0, message.content.length - stopSequences[i].length)
+                      const startS = startSequence[i] || ''
+                      if (message.content.startsWith(startS)) message.content = message.content.slice(startS.length)
+                      updateMessages(chatRequest.getChat().id)
+                    }
+                  }
+                }
+              }
+            }, 1)
+          }
+        }
+        ws.onclose = () => {
+          chatRequest.updating = false
+          chatRequest.updatingMessage = ''
+          chatResponse.updateFromClose()
+        }
+        ws.onerror = err => {
+          console.error(err)
+          throw err
+        }
+      }
+}
+</script>

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -53,6 +53,14 @@ export const runPetalsCompletionRequest = async (
             throw err
           }
           const rMessages = request.messages || [] as Message[]
+          // make sure top_p and temperature are set the way we need
+          let temperature = request.temperature || 0
+          if (isNaN(temperature as any) || temperature === 1) temperature = 1
+          if (temperature === 0) temperature = 0.0001
+          let topP = request.top_p
+          if (isNaN(topP as any) || topP === 1) topP = 1
+          if (topP === 0) topP = 0.0001
+          // build the message array
           const inputArray = (rMessages).reduce((a, m) => {
             const c = getRoleTag(m.role, model, chatRequest.chat) + m.content
             a.push(c)
@@ -65,11 +73,11 @@ export const runPetalsCompletionRequest = async (
           const petalsRequest = {
             type: 'generate',
             inputs: inputArray.join(stopSequence),
-            max_new_tokens: 3, // wait for up to 3 tokens before displaying
+            max_new_tokens: 1, // wait for up to 1 tokens before displaying
             stop_sequence: stopSequence,
-            doSample: 1,
-            temperature: request.temperature || 0,
-            top_p: request.top_p || 0,
+            do_sample: 1, // enable top p and the like
+            temperature,
+            top_p: topP,
             extra_stop_sequences: stopSequencesC
           }
           ws.send(JSON.stringify(petalsRequest))

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -56,11 +56,11 @@ export const runPetalsCompletionRequest = async (
           const rMessages = request.messages || [] as Message[]
           // make sure top_p and temperature are set the way we need
           let temperature = request.temperature || 0
-          if (isNaN(temperature as any) || temperature === 1) temperature = 1
-          if (temperature === 0) temperature = 0.0001
+          if (isNaN(temperature as any)) temperature = 1
+          if (!temperature || temperature <= 0) temperature = 0.01
           let topP = request.top_p
-          if (isNaN(topP as any) || topP === 1) topP = 1
-          if (topP === 0) topP = 0.0001
+          if (topP === undefined || isNaN(topP as any)) topP = 1
+          if (!topP || topP <= 0) topP = 0.01
           // build the message array
           const inputArray = (rMessages).reduce((a, m) => {
             const c = getRoleTag(m.role, model, chatRequest.chat) + m.content

--- a/src/lib/ChatSettingField.svelte
+++ b/src/lib/ChatSettingField.svelte
@@ -211,7 +211,7 @@
             {#key rkey}
             <select id="settings-{setting.key}" title="{setting.title}" on:change={e => queueSettingValueChange(e, setting) } >
               {#each setting.options as option}
-                <option class:is-default={option.value === chatDefaults[setting.key]} value={option.value} selected={option.value === chatSettings[setting.key]}>{option.text}</option>
+                <option class:is-default={option.value === chatDefaults[setting.key]} value={option.value} selected={option.value === chatSettings[setting.key]} disabled={option.disabled}>{option.text}</option>
               {/each}
             </select>
             {/key}

--- a/src/lib/ChatSettingField.svelte
+++ b/src/lib/ChatSettingField.svelte
@@ -3,7 +3,7 @@
   // import { getProfile } from './Profiles.svelte'
   import { cleanSettingValue, setChatSettingValue } from './Storage.svelte'
   import type { Chat, ChatSetting, ChatSettings, ControlAction, FieldControl, SettingPrompt } from './Types.svelte'
-  import { autoGrowInputOnEvent, errorNotice } from './Util.svelte'
+  import { autoGrowInputOnEvent, errorNotice, valueOf } from './Util.svelte'
   // import { replace } from 'svelte-spa-router'
   import Fa from 'svelte-fa/src/fa.svelte'
   import { openModal } from 'svelte-modals'
@@ -23,13 +23,9 @@
   const chatId = chat.id
   let show = false
 
-  const valueOf = (value: any) => {
-    if (typeof value === 'function') return value(chatId, setting)
-    return value
-  }
-
-  let header = valueOf(setting.header)
-  let headerClass = valueOf(setting.headerClass)
+  let header = valueOf(chatId, setting.header)
+  let headerClass = valueOf(chatId, setting.headerClass)
+  let placeholder = valueOf(chatId, setting.placeholder)
   
   const buildFieldControls = () => {
     fieldControls = (setting.fieldControls || [] as FieldControl[]).map(fc => {
@@ -46,8 +42,9 @@
 
   afterUpdate(() => {
     show = (typeof setting.hide !== 'function') || !setting.hide(chatId)
-    header = valueOf(setting.header)
-    headerClass = valueOf(setting.headerClass)
+    header = valueOf(chatId, setting.header)
+    headerClass = valueOf(chatId, setting.headerClass)
+    placeholder = valueOf(chatId, setting.placeholder)
     buildFieldControls()
   })
 
@@ -181,7 +178,7 @@
       <label class="label" for="settings-{setting.key}" title="{setting.title}">{setting.name}</label>
       <textarea
         class="input is-info is-focused chat-input auto-size"
-        placeholder={setting.placeholder || ''}
+        placeholder={placeholder || ''}
         rows="1"
         on:input={e => autoGrowInputOnEvent(e)}
         on:change={e => { queueSettingValueChange(e, setting); autoGrowInputOnEvent(e) }}
@@ -205,7 +202,7 @@
             min={setting.min}
             max={setting.max}
             step={setting.step}
-            placeholder={String(setting.placeholder || chatDefaults[setting.key])}
+            placeholder={String(placeholder || chatDefaults[setting.key])}
             on:change={e => queueSettingValueChange(e, setting)}
           />
         {:else if setting.type === 'select' || setting.type === 'select-number'}
@@ -243,6 +240,7 @@
               title="{setting.title}"
               class="input" 
               value={chatSettings[setting.key]} 
+              placeholder={String(placeholder || chatDefaults[setting.key])}
               on:change={e => { queueSettingValueChange(e, setting) }}
             >
           </div>

--- a/src/lib/ChatSettingField.svelte
+++ b/src/lib/ChatSettingField.svelte
@@ -22,6 +22,14 @@
 
   const chatId = chat.id
   let show = false
+
+  const valueOf = (value: any) => {
+    if (typeof value === 'function') return value(chatId, setting)
+    return value
+  }
+
+  let header = valueOf(setting.header)
+  let headerClass = valueOf(setting.headerClass)
   
   const buildFieldControls = () => {
     fieldControls = (setting.fieldControls || [] as FieldControl[]).map(fc => {
@@ -38,6 +46,8 @@
 
   afterUpdate(() => {
     show = (typeof setting.hide !== 'function') || !setting.hide(chatId)
+    header = valueOf(setting.header)
+    headerClass = valueOf(setting.headerClass)
     buildFieldControls()
   })
 
@@ -146,9 +156,9 @@
 </script>
 
 {#if show}
-  {#if setting.header}
-  <p class="notification {setting.headerClass}">
-    {@html setting.header}
+  {#if header}
+  <p class="notification {headerClass}">
+    {@html header}
   </p>
   {/if}
   <div class="field is-horizontal">

--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -3,7 +3,6 @@
   import { getChatDefaults, getChatSettingList, getChatSettingObjectByKey, getExcludeFromProfile } from './Settings.svelte'
   import {
     saveChatStore,
-    apiKeyStorage,
     chatsStorage,
     globalStorage,
     saveCustomProfile,
@@ -13,7 +12,7 @@
     checkStateChange,
     addChat
   } from './Storage.svelte'
-  import type { Chat, ChatSetting, ResponseModels, SettingSelect, SelectOption, ChatSettings } from './Types.svelte'
+  import type { Chat, ChatSetting, SettingSelect, ChatSettings } from './Types.svelte'
   import { errorNotice, sizeTextElements } from './Util.svelte'
   import Fa from 'svelte-fa/src/fa.svelte'
   import {
@@ -35,8 +34,7 @@
   import { replace } from 'svelte-spa-router'
   import { openModal } from 'svelte-modals'
   import PromptConfirm from './PromptConfirm.svelte'
-  import { getApiBase, getEndpointModels } from './ApiUtil.svelte'
-  import { supportedModelKeys } from './Models.svelte'
+  import { getModelOptions } from './Models.svelte'
 
   export let chatId:number
   export const show = () => { showSettings() }
@@ -184,31 +182,10 @@
 
     // Refresh settings modal
     showSettingsModal++
-  
-    // Load available models from OpenAI
-    const allModels = (await (
-      await fetch(getApiBase() + getEndpointModels(), {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${$apiKeyStorage}`,
-          'Content-Type': 'application/json'
-        }
-      })
-    ).json()) as ResponseModels
-    const filteredModels = supportedModelKeys.filter((model) => allModels.data.find((m) => m.id === model))
-
-    const modelOptions:SelectOption[] = filteredModels.reduce((a, m) => {
-      const o:SelectOption = {
-        value: m,
-        text: m
-      }
-      a.push(o)
-      return a
-    }, [] as SelectOption[])
 
     // Update the models in the settings
     if (modelSetting) {
-      modelSetting.options = modelOptions
+      modelSetting.options = await getModelOptions()
     }
     // Refresh settings modal
     showSettingsModal++

--- a/src/lib/EditMessage.svelte
+++ b/src/lib/EditMessage.svelte
@@ -11,6 +11,7 @@
   import { openModal } from 'svelte-modals'
   import PromptConfirm from './PromptConfirm.svelte'
   import { getImage } from './ImageStore.svelte'
+  import { getModelDetail } from './Models.svelte'
 
   export let message:Message
   export let chatId:number
@@ -245,7 +246,7 @@
       <p class="is-size-7 message-note">System Prompt</p>
     {:else if message.usage}
       <p class="is-size-7 message-note">
-        <em>{message.model || defaultModel}</em> using <span class="has-text-weight-bold">{message.usage.total_tokens}</span>
+        <em>{getModelDetail(message.model || '').label || message.model || defaultModel}</em> using <span class="has-text-weight-bold">{message.usage.total_tokens}</span>
         tokens ~= <span class="has-text-weight-bold">${getPrice(message.usage, message.model || defaultModel).toFixed(6)}</span>
       </p>
     {/if}

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -3,7 +3,7 @@
   import Footer from './Footer.svelte'
   import { replace } from 'svelte-spa-router'
   import { onMount } from 'svelte'
-  import { getPetalsV2Websocket } from './ApiUtil.svelte'
+  import { getPetals } from './ApiUtil.svelte'
 
 $: apiKey = $apiKeyStorage
 
@@ -112,7 +112,7 @@ const setPetalsEnabled = (event: Event) => {
               aria-label="PetalsAPI Endpoint"
               type="text"
               class="input"
-              placeholder={getPetalsV2Websocket()}
+              placeholder={getPetals()}
               value={$globalStorage.pedalsEndpoint || ''}
             />
           </p>
@@ -123,7 +123,7 @@ const setPetalsEnabled = (event: Event) => {
           
         </form>
         <p>
-          Only use <u>{getPetalsV2Websocket()}</u> for testing.  You must set up your own Petals server for actual use. 
+          Only use <u>{getPetals()}</u> for testing.  You must set up your own Petals server for actual use. 
         </p>
         <p>
           <b>Do not send sensitive information when using Petals.</b>

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -109,7 +109,7 @@ const setPetalsEnabled = (event: Event) => {
         checked={!!$globalStorage.enablePetals} 
         on:click={setPetalsEnabled}
       >
-        Use Petals API and Models
+        Use Petals API and Models (Llama 2)
       </label>
       {#if showPetalsSettings}
         <p>Set Petals API Endpoint:</p>

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-  import { apiKeyStorage, lastChatId, getChat, started } from './Storage.svelte'
+  import { apiKeyStorage, globalStorage, lastChatId, getChat, started, setGlobalSettingValueByKey } from './Storage.svelte'
   import Footer from './Footer.svelte'
   import { replace } from 'svelte-spa-router'
   import { onMount } from 'svelte'
+  import { getPetalsV2Websocket } from './ApiUtil.svelte'
 
 $: apiKey = $apiKeyStorage
+
+let showPetalsSettings = $globalStorage.enablePetals
 
 onMount(() => {
     if (!$started) {
@@ -18,6 +21,12 @@ onMount(() => {
     }
     $lastChatId = 0
 })
+
+const setPetalsEnabled = (event: Event) => {
+    const el = (event.target as HTMLInputElement)
+    setGlobalSettingValueByKey('enablePetals', !!el.checked)
+    showPetalsSettings = $globalStorage.enablePetals
+}
 
 </script>
 
@@ -60,8 +69,70 @@ onMount(() => {
         <p class="control">
           <button class="button is-info" type="submit">Save</button>
         </p>
+
+
       </form>
 
+      {#if !apiKey}
+        <p class="help is-danger">
+          Please enter your <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a> above to use ChatGPT-web.
+          It is required to use ChatGPT-web.
+        </p>
+      {/if}
+    </div>
+  </article>
+
+  
+  <article class="message" class:is-info={true}>
+    <div class="message-body">
+      <label class="label" for="enablePetals">
+        <input 
+        type="checkbox"
+        class="checkbox" 
+        id="enablePetals"
+        checked={!!$globalStorage.enablePetals} 
+        on:click={setPetalsEnabled}
+      >
+        Use Petals API and Models
+      </label>
+      {#if showPetalsSettings}
+        <p>Set Petals API Endpoint:</p>
+        <form
+          class="field has-addons has-addons-right"
+          on:submit|preventDefault={(event) => {
+            if (event.target && event.target[0].value) {
+              setGlobalSettingValueByKey('pedalsEndpoint', (event.target[0].value).trim())
+            } else {
+              setGlobalSettingValueByKey('pedalsEndpoint', '')
+            }
+          }}
+        >
+          <p class="control is-expanded">
+            <input
+              aria-label="PetalsAPI Endpoint"
+              type="text"
+              class="input"
+              placeholder={getPetalsV2Websocket()}
+              value={$globalStorage.pedalsEndpoint || ''}
+            />
+          </p>
+          <p class="control">
+            <button class="button is-info" type="submit">Save</button>
+          </p>
+
+          
+        </form>
+        <p>
+          Only use <u>{getPetalsV2Websocket()}</u> for testing.  You must set up your own Petals server for actual use. 
+        </p>
+        <p>
+          <b>Do not send sensitive information when using Petals.</b>
+        </p>
+        <p>
+            For more information on Petals, see 
+            <a href="https://github.com/petals-infra/chat.petals.dev">https://github.com/petals-infra/chat.petals.dev</a>
+        </p>
+      {/if}
       {#if !apiKey}
         <p class="help is-danger">
           Please enter your <a href="https://platform.openai.com/account/api-keys">OpenAI API key</a> above to use ChatGPT-web.

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -129,8 +129,8 @@ export const supportedModels : Record<string, ModelDetail> = {
       'gpt-4-32k': modelDetails['gpt-4-32k'],
       'gpt-4-32k-0314': modelDetails['gpt-4-32k'],
       'gpt-4-32k-0613': modelDetails['gpt-4-32k'],
-      'enoch/llama-65b-hf': modelDetails['enoch/llama-65b-hf'],
-      'timdettmers/guanaco-65b': modelDetails['timdettmers/guanaco-65b'],
+      // 'enoch/llama-65b-hf': modelDetails['enoch/llama-65b-hf'],
+      // 'timdettmers/guanaco-65b': modelDetails['timdettmers/guanaco-65b'],
       'meta-llama/Llama-2-70b-hf': modelDetails['meta-llama/Llama-2-70b-hf'],
       'meta-llama/Llama-2-70b-chat-hf': modelDetails['meta-llama/Llama-2-70b-chat-hf']
 }

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -42,27 +42,49 @@ const modelDetails : Record<string, ModelDetail> = {
         completion: 0.000004, // $0.004 per 1000 tokens completion
         max: 16384 // 16k max token buffer
       },
+      'enoch/llama-65b-hf': {
+        type: 'Petals',
+        label: 'Petals - Llama-65b',
+        stop: ['###', '</s>'],
+        userStart: '<|user|>',
+        assistantStart: '<|[[CHARACTER_NAME]]|>',
+        systemStart: '',
+        prompt: 0.000000, // $0.000 per 1000 tokens prompt
+        completion: 0.000000, // $0.000 per 1000 tokens completion
+        max: 2048 // 2k max token buffer
+      },
+      'timdettmers/guanaco-65b': {
+        type: 'Petals',
+        label: 'Petals - Guanaco-65b',
+        stop: ['###', '</s>'],
+        userStart: '<|user|>',
+        assistantStart: '<|[[CHARACTER_NAME]]|>',
+        systemStart: '',
+        prompt: 0.000000, // $0.000 per 1000 tokens prompt
+        completion: 0.000000, // $0.000 per 1000 tokens completion
+        max: 2048 // 2k max token buffer
+      },
       'meta-llama/Llama-2-70b-chat-hf': {
         type: 'Petals',
         label: 'Petals - Llama-2-70b-chat',
-        stop: ['</s>'],
-        userStart: '[user]',
-        assistantStart: '[[[CHARACTER_NAME]]]',
+        stop: ['###', '</s>'],
+        userStart: '<|user|>',
+        assistantStart: '<|[[CHARACTER_NAME]]|>',
         systemStart: '',
         prompt: 0.000000, // $0.000 per 1000 tokens prompt
         completion: 0.000000, // $0.000 per 1000 tokens completion
         max: 4096 // 4k max token buffer
       },
-      'timdettmers/guanaco-65b': {
+      'meta-llama/Llama-2-70b-hf': {
         type: 'Petals',
-        label: 'Petals - guanaco-65b',
-        stop: ['</s>'],
-        userStart: '[user]',
-        assistantStart: '[[[CHARACTER_NAME]]]',
+        label: 'Petals - Llama-2-70b',
+        stop: ['###', '</s>'],
+        userStart: '<|user|>',
+        assistantStart: '<|[[CHARACTER_NAME]]|>',
         systemStart: '',
         prompt: 0.000000, // $0.000 per 1000 tokens prompt
         completion: 0.000000, // $0.000 per 1000 tokens completion
-        max: 2048 // 2k max token buffer
+        max: 4096 // 4k max token buffer
       }
 }
 
@@ -107,8 +129,10 @@ export const supportedModels : Record<string, ModelDetail> = {
       'gpt-4-32k': modelDetails['gpt-4-32k'],
       'gpt-4-32k-0314': modelDetails['gpt-4-32k'],
       'gpt-4-32k-0613': modelDetails['gpt-4-32k'],
+      'enoch/llama-65b-hf': modelDetails['enoch/llama-65b-hf'],
+      'timdettmers/guanaco-65b': modelDetails['timdettmers/guanaco-65b'],
+      'meta-llama/Llama-2-70b-hf': modelDetails['meta-llama/Llama-2-70b-hf'],
       'meta-llama/Llama-2-70b-chat-hf': modelDetails['meta-llama/Llama-2-70b-chat-hf']
-      // 'timdettmers/guanaco-65b': modelDetails['timdettmers/guanaco-65b']
 }
 
 const lookupList = {
@@ -154,27 +178,27 @@ export const getEndpoint = (model: Model): string => {
 }
 
 export const getStopSequence = (chat: Chat): string => {
-  return valueOf(chat.id, getChatSettingObjectByKey('stopSequence').placeholder)
+  return chat.settings.stopSequence || valueOf(chat.id, getChatSettingObjectByKey('stopSequence').placeholder)
 }
 
 export const getUserStart = (chat: Chat): string => {
   return mergeProfileFields(
         chat.settings,
-        valueOf(chat.id, getChatSettingObjectByKey('userMessageStart').placeholder)
+        chat.settings.userMessageStart || valueOf(chat.id, getChatSettingObjectByKey('userMessageStart').placeholder)
       )
 }
 
 export const getAssistantStart = (chat: Chat): string => {
   return mergeProfileFields(
         chat.settings,
-        valueOf(chat.id, getChatSettingObjectByKey('assistantMessageStart').placeholder)
+        chat.settings.assistantMessageStart || valueOf(chat.id, getChatSettingObjectByKey('assistantMessageStart').placeholder)
       )
 }
 
 export const getSystemStart = (chat: Chat): string => {
   return mergeProfileFields(
         chat.settings,
-        valueOf(chat.id, getChatSettingObjectByKey('systemMessageStart').placeholder)
+        chat.settings.systemMessageStart || valueOf(chat.id, getChatSettingObjectByKey('systemMessageStart').placeholder)
       )
 }
 

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -252,7 +252,8 @@ export async function getModelOptions (): Promise<SelectOption[]> {
 
   const modelOptions:SelectOption[] = Object.keys(supportedModels).reduce((a, m) => {
         let disabled
-        switch (getModelDetail(m).type) {
+        const modelDetail = getModelDetail(m)
+        switch (modelDetail.type) {
           case 'Petals':
             disabled = !gSettings.enablePetals
             break
@@ -262,7 +263,7 @@ export async function getModelOptions (): Promise<SelectOption[]> {
         }
         const o:SelectOption = {
           value: m,
-          text: m,
+          text: modelDetail.label || m,
           disabled
         }
         a.push(o)

--- a/src/lib/Profiles.svelte
+++ b/src/lib/Profiles.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import { getChatDefaults, getExcludeFromProfile } from './Settings.svelte'
+  import { getChatDefaults, getDefaultModel, getExcludeFromProfile } from './Settings.svelte'
   import { get, writable } from 'svelte/store'
   // Profile definitions
   import { addMessage, clearMessages, deleteMessage, getChat, getChatSettings, getCustomProfiles, getGlobalSettings, getMessages, newName, resetChatSettings, saveChatStore, setGlobalSettingValueByKey, setMessages, updateProfile } from './Storage.svelte'
@@ -22,7 +22,9 @@ export const getProfiles = (forceUpdate:boolean = false):Record<string, ChatSett
     }
     const result = Object.entries(profiles
     ).reduce((a, [k, v]) => {
+      v = JSON.parse(JSON.stringify(v))
       a[k] = v
+      v.model = v.model || getDefaultModel()
       return a
     }, {} as Record<string, ChatSettings>)
     Object.entries(getCustomProfiles()).forEach(([k, v]) => {

--- a/src/lib/Profiles.svelte
+++ b/src/lib/Profiles.svelte
@@ -72,7 +72,7 @@ export const getProfile = (key:string, forReset:boolean = false):ChatSettings =>
 
 export const mergeProfileFields = (settings: ChatSettings, content: string|undefined, maxWords: number|undefined = undefined): string => {
     if (!content?.toString) return ''
-    content = (content + '').replaceAll('[[CHARACTER_NAME]]', settings.characterName || 'ChatGPT')
+    content = (content + '').replaceAll('[[CHARACTER_NAME]]', settings.characterName || 'Assistant')
     if (maxWords) content = (content + '').replaceAll('[[MAX_WORDS]]', maxWords.toString())
     return content
 }

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -1,7 +1,6 @@
 <script context="module" lang="ts">
     import { applyProfile } from './Profiles.svelte'
     import { getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
-    import { encode } from 'gpt-tokenizer'
     import { faArrowDown91, faArrowDownAZ, faCheck, faThumbTack } from '@fortawesome/free-solid-svg-icons/index'
 // Setting definitions
 
@@ -18,6 +17,7 @@ import {
       type ChatSortOption
 
 } from './Types.svelte'
+    import { getTokens } from './Models.svelte'
 
 export const defaultModel:Model = 'gpt-3.5-turbo'
 
@@ -104,7 +104,10 @@ export const globalDefaults: GlobalSettings = {
   lastProfile: 'default',
   defaultProfile: 'default',
   hideSummarized: false,
-  chatSort: 'created'
+  chatSort: 'created',
+  openAICompletionEndpoint: '',
+  enablePetals: false,
+  pedalsEndpoint: ''
 }
 
 const excludeFromProfile = {
@@ -497,7 +500,7 @@ const chatSettingsList: ChatSetting[] = [
           // console.log('logit_bias', val, getChatSettings(chatId).logit_bias)
           if (!val) return null
           const tokenized:Record<number, number> = Object.entries(val).reduce((a, [k, v]) => {
-            const tokens:number[] = encode(k)
+            const tokens:number[] = getTokens(getChatSettings(chatId).model, k)
             tokens.forEach(t => { a[t] = v })
             return a
           }, {} as Record<number, number>)
@@ -536,6 +539,21 @@ const globalSettingsList:GlobalSetting[] = [
         key: 'hideSummarized',
         name: 'Hide Summarized Messages',
         type: 'boolean'
+      },
+      {
+        key: 'openAICompletionEndpoint',
+        name: 'OpenAI Completions Endpoint',
+        type: 'text'
+      },
+      {
+        key: 'enablePetals',
+        name: 'Enable Petals APIs',
+        type: 'boolean'
+      },
+      {
+        key: 'pedalsEndpoint',
+        name: 'Petals API Endpoint',
+        type: 'text'
       }
 ]
 

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -94,6 +94,10 @@ const defaults:ChatSettings = {
   hppContinuePrompt: '',
   hppWithSummaryPrompt: false,
   imageGenerationSize: '',
+  stopSequence: '',
+  userMessageStart: '',
+  assistantMessageStart: '',
+  systemMessageStart: '',
   // useResponseAlteration: false,
   // responseAlterations: [],
   isDirty: false
@@ -414,6 +418,10 @@ const isNotOpenAI = (chatId) => {
   return getModelDetail(getChatSettings(chatId).model).type !== 'OpenAIChat'
 }
 
+const isNotPetals = (chatId) => {
+  return getModelDetail(getChatSettings(chatId).model).type !== 'Petals'
+}
+
 const chatSettingsList: ChatSetting[] = [
       profileSetting,
       ...systemPromptSettings,
@@ -491,6 +499,50 @@ const chatSettingsList: ChatSetting[] = [
         step: 0.2,
         type: 'number',
         hide: isNotOpenAI
+      },
+      {
+        key: 'stopSequence',
+        name: 'Stop Sequence',
+        title: 'Characters used to separate messages in the message chain.',
+        type: 'text',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).stop
+          return (val && val[0]) || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'userMessageStart',
+        name: 'User Message Start Sequence',
+        title: 'Sequence to denote user messages in the message chain.',
+        type: 'text',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).userStart
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'assistantMessageStart',
+        name: 'Assistant Message Start Sequence',
+        title: 'Sequence to denote assistant messages in the message chain.',
+        type: 'text',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).assistantStart
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'systemMessageStart',
+        name: 'System Message Start Sequence',
+        title: 'Sequence to denote system messages in the message chain.',
+        type: 'text',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).systemStart
+          return val || ''
+        },
+        hide: isNotPetals
       },
       {
         // logit bias editor not implemented yet

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -55,6 +55,14 @@ export const getExcludeFromProfile = () => {
   return excludeFromProfile
 }
 
+const isNotOpenAI = (chatId) => {
+  return getModelDetail(getChatSettings(chatId).model).type !== 'OpenAIChat'
+}
+
+const isNotPetals = (chatId) => {
+  return getModelDetail(getChatSettings(chatId).model).type !== 'Petals'
+}
+
 const gptDefaults = {
   model: defaultModel,
   messages: [],
@@ -406,20 +414,18 @@ const modelSetting: ChatSetting & SettingSelect = {
       key: 'model',
       name: 'Model',
       title: 'The model to use - GPT-3.5 is cheaper, but GPT-4 is more powerful.',
-      header: 'Below are the settings that OpenAI allows to be changed for the API calls. See the <a target="_blank" href="https://platform.openai.com/docs/api-reference/chat/create">OpenAI API docs</a> for more details.',
+      header: (chatId) => {
+        if (isNotOpenAI(chatId)) {
+          return 'Below are the settings that can be changed for the API calls. See <a target="_blank" href="https://platform.openai.com/docs/api-reference/chat/create">this overview</a> to start, though not all settings translate to Petals.'
+        } else {
+          return 'Below are the settings that OpenAI allows to be changed for the API calls. See the <a target="_blank" href="https://platform.openai.com/docs/api-reference/chat/create">OpenAI API docs</a> for more details.'
+        }
+      },
       headerClass: 'is-warning',
       options: [],
       type: 'select',
       forceApi: true, // Need to make sure we send this
       afterChange: (chatId, setting) => true // refresh settings
-}
-
-const isNotOpenAI = (chatId) => {
-  return getModelDetail(getChatSettings(chatId).model).type !== 'OpenAIChat'
-}
-
-const isNotPetals = (chatId) => {
-  return getModelDetail(getChatSettings(chatId).model).type !== 'Petals'
 }
 
 const chatSettingsList: ChatSetting[] = [
@@ -448,7 +454,7 @@ const chatSettingsList: ChatSetting[] = [
       },
       {
         key: 'top_p',
-        name: 'Nucleus Sampling',
+        name: 'Nucleus Sampling (Top-p)',
         title: 'An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n' +
               '\n' +
               'We generally recommend altering this or temperature but not both',

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -17,7 +17,7 @@ import {
       type ChatSortOption
 
 } from './Types.svelte'
-    import { getTokens } from './Models.svelte'
+    import { getModelDetail, getTokens } from './Models.svelte'
 
 export const defaultModel:Model = 'gpt-3.5-turbo'
 
@@ -410,6 +410,10 @@ const modelSetting: ChatSetting & SettingSelect = {
       afterChange: (chatId, setting) => true // refresh settings
 }
 
+const isNotOpenAI = (chatId) => {
+  return getModelDetail(getChatSettings(chatId).model).type !== 'OpenAIChat'
+}
+
 const chatSettingsList: ChatSetting[] = [
       profileSetting,
       ...systemPromptSettings,
@@ -420,7 +424,8 @@ const chatSettingsList: ChatSetting[] = [
         key: 'stream',
         name: 'Stream Response',
         title: 'Stream responses as they are generated.',
-        type: 'boolean'
+        type: 'boolean',
+        hide: isNotOpenAI
       },
       {
         key: 'temperature',
@@ -451,7 +456,8 @@ const chatSettingsList: ChatSetting[] = [
         min: 1,
         max: 10,
         step: 1,
-        type: 'number'
+        type: 'number',
+        hide: isNotOpenAI
       },
       {
         key: 'max_tokens',
@@ -463,6 +469,7 @@ const chatSettingsList: ChatSetting[] = [
         max: 32768,
         step: 1,
         type: 'number',
+        hide: isNotOpenAI,
         forceApi: true // Since default here is different than gpt default, will make sure we always send it
       },
       {
@@ -472,7 +479,8 @@ const chatSettingsList: ChatSetting[] = [
         min: -2,
         max: 2,
         step: 0.2,
-        type: 'number'
+        type: 'number',
+        hide: isNotOpenAI
       },
       {
         key: 'frequency_penalty',
@@ -481,7 +489,8 @@ const chatSettingsList: ChatSetting[] = [
         min: -2,
         max: 2,
         step: 0.2,
-        type: 'number'
+        type: 'number',
+        hide: isNotOpenAI
       },
       {
         // logit bias editor not implemented yet

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -1,6 +1,7 @@
 <script context="module" lang="ts">
     import { applyProfile } from './Profiles.svelte'
-    import { getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
+    import { get } from 'svelte/store'
+    import { apiKeyStorage, getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
     import { faArrowDown91, faArrowDownAZ, faCheck, faThumbTack } from '@fortawesome/free-solid-svg-icons/index'
 // Setting definitions
 
@@ -19,7 +20,13 @@ import {
 } from './Types.svelte'
     import { getModelDetail, getTokens } from './Models.svelte'
 
-export const defaultModel:Model = 'gpt-3.5-turbo'
+const defaultModel:Model = 'gpt-3.5-turbo'
+const defaultModelPetals:Model = 'meta-llama/Llama-2-70b-chat-hf'
+
+export const getDefaultModel = (): Model => {
+  if (!get(apiKeyStorage)) return defaultModelPetals
+  return defaultModel
+}
 
 export const getChatSettingList = (): ChatSetting[] => {
       return chatSettingsList
@@ -64,7 +71,7 @@ const isNotPetals = (chatId) => {
 }
 
 const gptDefaults = {
-  model: defaultModel,
+  model: '',
   messages: [],
   temperature: 1,
   top_p: 1,

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { params } from 'svelte-spa-router'
   import ChatMenuItem from './ChatMenuItem.svelte'
-  import { apiKeyStorage, chatsStorage, pinMainMenu, checkStateChange, getChatSortOption, setChatSortOption } from './Storage.svelte'
+  import { apiKeyStorage, chatsStorage, pinMainMenu, checkStateChange, getChatSortOption, setChatSortOption, hasActiveModels } from './Storage.svelte'
   import Fa from 'svelte-fa/src/fa.svelte'
   import { faSquarePlus, faKey } from '@fortawesome/free-solid-svg-icons/index'
   import ChatOptionMenu from './ChatOptionMenu.svelte'
@@ -14,10 +14,12 @@
   $: activeChatId = $params && $params.chatId ? parseInt($params.chatId) : undefined
 
   let sortOption = getChatSortOption()
+  let hasModels = hasActiveModels()
 
   const onStateChange = (...args:any) => {
     sortOption = getChatSortOption()
     sortedChats = $chatsStorage.sort(sortOption.sortFn)
+    hasModels = hasActiveModels()
   }
 
   $: onStateChange($checkStateChange)
@@ -72,14 +74,14 @@
         </div>
       </div>
       <div class="level-right">
-        {#if !$apiKeyStorage}
+        {#if !hasModels}
         <div class="level-item">
           <a href={'#/'} class="panel-block" class:is-disabled={!$apiKeyStorage}
             ><span class="greyscale mr-1"><Fa icon={faKey} /></span> API key</a
           ></div>
         {:else}
         <div class="level-item">
-          <button on:click={() => { $pinMainMenu = false; startNewChatWithWarning(activeChatId) }} class="panel-block button" title="Start new chat with default profile" class:is-disabled={!$apiKeyStorage}
+          <button on:click={() => { $pinMainMenu = false; startNewChatWithWarning(activeChatId) }} class="panel-block button" title="Start new chat with default profile" class:is-disabled={!hasModels}
             ><span class="greyscale mr-1"><Fa icon={faSquarePlus} /></span> New chat</button>
           </div>
         {/if}

--- a/src/lib/Stats.svelte
+++ b/src/lib/Stats.svelte
@@ -1,16 +1,16 @@
 <script context="module" lang="ts">
-  import { countTokens, getModelDetail, getRoleTag } from './Models.svelte'
-  import type { ChatSettings, Message, Model, Usage } from './Types.svelte'
+  import { countTokens, getModelDetail, getRoleTag, getStopSequence } from './Models.svelte'
+  import type { Chat, Message, Model, Usage } from './Types.svelte'
 
   export const getPrice = (tokens: Usage, model: Model): number => {
     const t = getModelDetail(model)
     return ((tokens.prompt_tokens * t.prompt) + (tokens.completion_tokens * t.completion))
   }
 
-  export const countPromptTokens = (prompts:Message[], model:Model, settings: ChatSettings):number => {
+  export const countPromptTokens = (prompts:Message[], model:Model, chat: Chat):number => {
     const detail = getModelDetail(model)
     const count = prompts.reduce((a, m) => {
-      a += countMessageTokens(m, model, settings)
+      a += countMessageTokens(m, model, chat)
       return a
     }, 0)
     switch (detail.type) {
@@ -25,13 +25,12 @@
     }
   }
 
-  export const countMessageTokens = (message:Message, model:Model, settings: ChatSettings):number => {
+  export const countMessageTokens = (message:Message, model:Model, chat: Chat):number => {
     const detail = getModelDetail(model)
-    const start = detail.start && detail.start[0]
-    const stop = detail.stop && detail.stop[0]
+    const stop = getStopSequence(chat)
     switch (detail.type) {
       case 'Petals':
-        return countTokens(model, (start || '') + getRoleTag(message.role, model, settings) + ': ' + message.content + (stop || '###'))
+        return countTokens(model, getRoleTag(message.role, model, chat) + ': ' + message.content + (stop || '###'))
       case 'OpenAIChat':
       default:
         // Not sure how OpenAI formats it, but this seems to get close to the right counts.

--- a/src/lib/Stats.svelte
+++ b/src/lib/Stats.svelte
@@ -1,25 +1,49 @@
 <script context="module" lang="ts">
-  import { getModelDetail } from './Models.svelte'
-  import type { Message, Model, Usage } from './Types.svelte'
-  import { encode } from 'gpt-tokenizer'
+  import { countTokens, getModelDetail, getRoleTag } from './Models.svelte'
+  import type { ChatSettings, Message, Model, Usage } from './Types.svelte'
 
   export const getPrice = (tokens: Usage, model: Model): number => {
     const t = getModelDetail(model)
     return ((tokens.prompt_tokens * t.prompt) + (tokens.completion_tokens * t.completion))
   }
 
-  export const countPromptTokens = (prompts:Message[], model:Model):number => {
-    return prompts.reduce((a, m) => {
-      a += countMessageTokens(m, model)
+  export const countPromptTokens = (prompts:Message[], model:Model, settings: ChatSettings):number => {
+    const detail = getModelDetail(model)
+    const count = prompts.reduce((a, m) => {
+      switch (detail.type) {
+        case 'PetalsV2Websocket':
+          a += countMessageTokens(m, model, settings)
+          break
+        case 'OpenAIChat':
+        default:
+          a += countMessageTokens(m, model, settings)
+      }
       return a
-    }, 0) + 3 // Always seems to be message counts + 3
+    }, 0)
+    switch (detail.type) {
+      case 'PetalsV2Websocket':
+        return count + (Math.max(prompts.length - 1, 0) * countTokens(model, (detail.stop && detail.stop[0]) || '###')) // todo, make stop per model?
+      case 'OpenAIChat':
+      default:
+        // Not sure how OpenAI formats it, but this seems to get close to the right counts.
+        // Would be nice to know. This works for gpt-3.5.  gpt-4 could be different.
+        // Complete stab in the dark here -- update if you know where all the extra tokens really come from.
+        return count + 3 // Always seems to be message counts + 3
+    }
   }
 
-  export const countMessageTokens = (message:Message, model:Model):number => {
-    // Not sure how OpenAI formats it, but this seems to get close to the right counts.
-    // Would be nice to know. This works for gpt-3.5.  gpt-4 could be different.
-    // Complete stab in the dark here -- update if you know where all the extra tokens really come from.
-    return encode('## ' + message.role + ' ##:\r\n\r\n' + message.content + '\r\n\r\n\r\n').length
+  export const countMessageTokens = (message:Message, model:Model, settings: ChatSettings):number => {
+    const detail = getModelDetail(model)
+    switch (detail.type) {
+      case 'PetalsV2Websocket':
+        return countTokens(model, getRoleTag(message.role, model, settings) + ': ' + message.content)
+      case 'OpenAIChat':
+      default:
+        // Not sure how OpenAI formats it, but this seems to get close to the right counts.
+        // Would be nice to know. This works for gpt-3.5.  gpt-4 could be different.
+        // Complete stab in the dark here -- update if you know where all the extra tokens really come from.
+        return countTokens(model, '## ' + message.role + ' ##:\r\n\r\n' + message.content + '\r\n\r\n\r\n')
+    }
   }
 
   export const getModelMaxTokens = (model:Model):number => {

--- a/src/lib/Stats.svelte
+++ b/src/lib/Stats.svelte
@@ -10,19 +10,12 @@
   export const countPromptTokens = (prompts:Message[], model:Model, settings: ChatSettings):number => {
     const detail = getModelDetail(model)
     const count = prompts.reduce((a, m) => {
-      switch (detail.type) {
-        case 'PetalsV2Websocket':
-          a += countMessageTokens(m, model, settings)
-          break
-        case 'OpenAIChat':
-        default:
-          a += countMessageTokens(m, model, settings)
-      }
+      a += countMessageTokens(m, model, settings)
       return a
     }, 0)
     switch (detail.type) {
-      case 'PetalsV2Websocket':
-        return count + (Math.max(prompts.length - 1, 0) * countTokens(model, (detail.stop && detail.stop[0]) || '###')) // todo, make stop per model?
+      case 'Petals':
+        return count
       case 'OpenAIChat':
       default:
         // Not sure how OpenAI formats it, but this seems to get close to the right counts.
@@ -34,9 +27,11 @@
 
   export const countMessageTokens = (message:Message, model:Model, settings: ChatSettings):number => {
     const detail = getModelDetail(model)
+    const start = detail.start && detail.start[0]
+    const stop = detail.stop && detail.stop[0]
     switch (detail.type) {
-      case 'PetalsV2Websocket':
-        return countTokens(model, getRoleTag(message.role, model, settings) + ': ' + message.content)
+      case 'Petals':
+        return countTokens(model, (start || '') + getRoleTag(message.role, model, settings) + ': ' + message.content + (stop || '###'))
       case 'OpenAIChat':
       default:
         // Not sure how OpenAI formats it, but this seems to get close to the right counts.

--- a/src/lib/Storage.svelte
+++ b/src/lib/Storage.svelte
@@ -25,9 +25,14 @@
   export let lastChatId = persisted('lastChatId', 0)
 
   const chatDefaults = getChatDefaults()
-
+  
   export const getApiKey = (): string => {
     return get(apiKeyStorage)
+  }
+
+  export const hasActiveModels = (): boolean => {
+    const globalSettings = get(globalStorage) || {}
+    return !!get(apiKeyStorage) || !!globalSettings.enablePetals
   }
 
   export const newChatID = (): number => {

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -199,6 +199,7 @@ export type GlobalSettings = {
 export type SelectOption = {
     value: string|number;
     text: string;
+    disabled?: boolean;
   };
 
 export type ChatSortOption = SelectOption & {

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -7,7 +7,12 @@ export type Model = typeof supportedModelKeys[number];
 
 export type ImageGenerationSizes = typeof imageGenerationSizeTypes[number];
 
+export type RequestType = 'OpenAIChat' | 'OpenAIDall-e' | 'PetalsV2Websocket'
+
 export type ModelDetail = {
+    type: RequestType;
+    label?: string;
+    stop?: string[];
     prompt: number;
     completion: number;
     max: number;
@@ -122,16 +127,16 @@ export type Chat = {
   };
 
   type ResponseOK = {
-    id: string;
-    object: string;
-    created: number;
-    choices: {
-      index: number;
+    id?: string;
+    object?: string;
+    created?: number;
+    choices?: {
+      index?: number;
       message: Message;
-      finish_reason: string;
+      finish_reason?: string;
       delta: Message;
     }[];
-    usage: Usage;
+    usage?: Usage;
     model: Model;
   };
 
@@ -172,6 +177,9 @@ export type GlobalSettings = {
     defaultProfile: string;
     hideSummarized: boolean;
     chatSort: ChatSortOptions;
+    openAICompletionEndpoint: string;
+    enablePetals: boolean;
+    pedalsEndpoint: string;
   };
 
   type SettingNumber = {

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -13,7 +13,9 @@ export type ModelDetail = {
     type: RequestType;
     label?: string;
     stop?: string[];
-    start?: string[];
+    userStart?: string,
+    assistantStart?: string,
+    systemStart?: string,
     prompt: number;
     completion: number;
     max: number;
@@ -111,6 +113,10 @@ export type ChatSettings = {
     trainingPrompts?: Message[];
     useResponseAlteration?: boolean;
     responseAlterations?: ResponseAlteration[];
+    stopSequence: string;
+    userMessageStart: string;
+    assistantMessageStart: string;
+    systemMessageStart: string;
     isDirty?: boolean;
   } & Request;
 
@@ -245,6 +251,8 @@ export type SubSetting = {
     settings: any[];
   };
 
+export type ValueFn = (chatId:number) => string
+
 export type ChatSetting = {
     key: keyof ChatSettings;
     name: string;
@@ -253,7 +261,7 @@ export type ChatSetting = {
     hidden?: boolean; // Hide from setting menus
     header?: string;
     headerClass?: string;
-    placeholder?: string;
+    placeholder?: string | ValueFn;
     hide?: (chatId:number) => boolean;
     apiTransform?: (chatId:number, setting:ChatSetting, value:any) => any;
     fieldControls?: FieldControl[];

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -7,12 +7,13 @@ export type Model = typeof supportedModelKeys[number];
 
 export type ImageGenerationSizes = typeof imageGenerationSizeTypes[number];
 
-export type RequestType = 'OpenAIChat' | 'OpenAIDall-e' | 'PetalsV2Websocket'
+export type RequestType = 'OpenAIChat' | 'OpenAIDall-e' | 'Petals'
 
 export type ModelDetail = {
     type: RequestType;
     label?: string;
     stop?: string[];
+    start?: string[];
     prompt: number;
     completion: number;
     max: number;

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -259,8 +259,8 @@ export type ChatSetting = {
     title: string;
     forceApi?: boolean; // force in api requests, even if set to default
     hidden?: boolean; // Hide from setting menus
-    header?: string;
-    headerClass?: string;
+    header?: string | ValueFn;
+    headerClass?: string | ValueFn;
     placeholder?: string | ValueFn;
     hide?: (chatId:number) => boolean;
     apiTransform?: (chatId:number, setting:ChatSetting, value:any) => any;

--- a/src/lib/Util.svelte
+++ b/src/lib/Util.svelte
@@ -147,4 +147,9 @@
     newChat()
   }
 
+  export const valueOf = (chatId: number, value: any) => {
+    if (typeof value === 'function') return value(chatId)
+    return value
+  }
+
 </script> 


### PR DESCRIPTION
Adds experimental support for Llama 2 70b using Petals:
https://github.com/petals-infra/chat.petals.dev

Enable it on the home page.
The default endpoint for it should be overridden with your own Petals server.  The one included is only for testing.
