### PR TITLE
Add an "Aggressive stop" sequence setting for Petals API calls

### DIFF
--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -150,6 +150,9 @@ const setPetalsEnabled = (event: Event) => {
         <p class="mb-4">
           You are encouraged to <a target="_blank" href="https://github.com/bigscience-workshop/petals/wiki/FAQ:-Frequently-asked-questions#running-a-server">set up a Petals server to share your GPU resources</a> with the public swarm. Minimum requirements to contribute Llama 2 completions are a GTX&nbsp;1080&nbsp;8GB, but the larger/faster the better.
         </p>
+        <p class="mb-4">
+          If you're receiving errors while using Petals, <a target="_blank" href="https://health.petals.dev/">check swarm health</a> and consider <a target="_blank" href="https://github.com/bigscience-workshop/petals/wiki/FAQ:-Frequently-asked-questions#running-a-server">adding your GPU to the swarm</a> to help.
+        </p>
         <p class="help is-warning">
           Because Petals uses a public swarm, <b>do not send sensitive information</b> when using Petals.
         </p>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -110,6 +110,7 @@ const defaults:ChatSettings = {
   hppWithSummaryPrompt: false,
   imageGenerationSize: '',
   stopSequence: '',
+  aggressiveStop: false,
   userMessageStart: '',
   assistantMessageStart: '',
   systemMessageStart: '',
@@ -522,6 +523,13 @@ const chatSettingsList: ChatSetting[] = [
           const val = getModelDetail(getChatSettings(chatId).model).stop
           return (val && val[0]) || ''
         },
+        hide: isNotPetals
+      },
+      {
+        key: 'aggressiveStop',
+        name: 'Use aggressive stop',
+        title: 'Sometimes generation con continue even after a stop sequence. This will stop generation client side if generation continues after stop sequence.',
+        type: 'boolean',
         hide: isNotPetals
       },
       {

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -528,7 +528,7 @@ const chatSettingsList: ChatSetting[] = [
       {
         key: 'aggressiveStop',
         name: 'Use aggressive stop',
-        title: 'Sometimes generation con continue even after a stop sequence. This will stop generation client side if generation continues after stop sequence.',
+        title: 'Sometimes generation can continue even after a stop sequence. This will stop generation client side if generation continues after stop sequence.',
         type: 'boolean',
         hide: isNotPetals
       },

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -114,6 +114,7 @@ export type ChatSettings = {
     useResponseAlteration?: boolean;
     responseAlterations?: ResponseAlteration[];
     stopSequence: string;
+    aggressiveStop: boolean;
     userMessageStart: string;
     assistantMessageStart: string;
     systemMessageStart: string;


### PR DESCRIPTION
Sometimes the stop sequence isn't detected by the host API and generation continues after it should have been stopped.  This adds an option that more aggressively looks for the stop sequence that may have passed through and drops the connection if it finds it. 