### PR TITLE
Close websocket connections, Format Llama-2-chat requests to Meta spec.

### DIFF
--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
     import ChatCompletionResponse from './ChatCompletionResponse.svelte'
     import ChatRequest from './ChatRequest.svelte'
-    import { getEndpoint, getModelDetail, getRoleTag, getStopSequence } from './Models.svelte'
+    import { getDeliminator, getEndpoint, getLeadPrompt, getModelDetail, getRoleEnd, getRoleTag, getStartSequence, getStopSequence } from './Models.svelte'
     import type { ChatCompletionOpts, Message, Request } from './Types.svelte'
     import { getModelMaxTokens } from './Stats.svelte'
     import { updateMessages } from './Storage.svelte'
@@ -27,13 +27,18 @@ export const runPetalsCompletionRequest = async (
       signal.addEventListener('abort', abortListener)
       const stopSequences = (modelDetail.stop || ['###', '</s>']).slice()
       const stopSequence = getStopSequence(chat)
+      const deliminator = getDeliminator(chat)
+      if (deliminator) stopSequences.unshift(deliminator)
       let stopSequenceC = stopSequence
       if (stopSequence !== '###') {
         stopSequences.push(stopSequence)
         stopSequenceC = '</s>'
       }
+      const haveSeq = {}
       const stopSequencesC = stopSequences.filter((ss) => {
-        return ss !== '###' && ss !== stopSequenceC
+        const have = haveSeq[ss]
+        haveSeq[ss] = true
+        return !have && ss !== '###' && ss !== stopSequenceC
       })
       const maxTokens = getModelMaxTokens(model)
       let maxLen = Math.min(opts.maxTokens || chatRequest.chat.max_tokens || maxTokens, maxTokens)
@@ -69,7 +74,21 @@ export const runPetalsCompletionRequest = async (
             console.error(err)
             throw err
           }
-          const rMessages = request.messages || [] as Message[]
+          // Enforce strict order of messages
+          const fMessages = (request.messages || [] as Message[])
+          const rMessages = fMessages.reduce((a, m, i) => {
+            a.push(m)
+            const nm = fMessages[i + 1]
+            if (m.role === 'system' && (!nm || nm.role !== 'user')) {
+              const nc = {
+                role: 'user',
+                content: ''
+              } as Message
+              a.push(nc)
+            }
+            return a
+          },
+          [] as Message[])
           // make sure top_p and temperature are set the way we need
           let temperature = request.temperature
           if (temperature === undefined || isNaN(temperature as any)) temperature = 1
@@ -78,18 +97,51 @@ export const runPetalsCompletionRequest = async (
           if (topP === undefined || isNaN(topP as any)) topP = 1
           if (!topP || topP <= 0) topP = 0.01
           // build the message array
-          const inputArray = (rMessages).reduce((a, m) => {
-            const c = getRoleTag(m.role, model, chatRequest.chat) + m.content
-            a.push(c.trim())
-            return a
-          }, [] as string[])
-          const lastMessage = rMessages[rMessages.length - 1]
-          if (lastMessage && lastMessage.role !== 'assistant') {
-            inputArray.push(getRoleTag('assistant', model, chatRequest.chat))
+          const buildMessage = (m: Message): string => {
+            return getRoleTag(m.role, model, chat) + m.content + getRoleEnd(m.role, model, chat)
           }
+          const dupe = JSON.parse(JSON.stringify(rMessages))
+          const inputArray = rMessages.reduce((a, m, i) => {
+            let c = buildMessage(m)
+            let replace = false
+            const lm = a[a.length - 1]
+            // Merge content if needed
+            if (lm) {
+              if (lm.role === 'system' && m.role === 'user' && c.includes('[[SYSTEM_PROMPT]]')) {
+                console.log('do rep', lm, m)
+                c = c.replaceAll('[[SYSTEM_PROMPT]]', lm.content)
+                replace = true
+              } else {
+                console.log('no rep', lm, m)
+                c = c.replaceAll('[[SYSTEM_PROMPT]]', '')
+              }
+              if (lm.role === 'user' && m.role === 'assistant' && c.includes('[[USER_PROMPT]]')) {
+                c = c.replaceAll('[[USER_PROMPT]]', lm.content)
+                replace = true
+              } else {
+                c = c.replaceAll('[[USER_PROMPT]]', '')
+              }
+            }
+            // Clean up merge fields on last
+            if (!rMessages[i + 1]) {
+              c = c.replaceAll('[[USER_PROMPT]]', '').replaceAll('[[SYSTEM_PROMPT]]', '')
+            }
+            const result = {
+              role: m.role,
+              content: c.trim()
+            } as Message
+            if (replace) {
+              a[a.length - 1] = result
+            } else {
+              a.push(result)
+            }
+            return a
+          }, [] as Message[])
+          console.log('message debug', dupe, rMessages, inputArray)
+          const leadPrompt = ((inputArray[inputArray.length - 1] || {}) as Message).role !== 'assistant' ? getLeadPrompt(chat) : ''
           const petalsRequest = {
             type: 'generate',
-            inputs: inputArray.join(stopSequence),
+            inputs: getStartSequence(chat) + inputArray.map(m => m.content).join(deliminator) + leadPrompt,
             max_new_tokens: 1, // wait for up to 1 tokens before displaying
             stop_sequence: stopSequenceC,
             do_sample: 1, // enable top p and the like

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -108,11 +108,9 @@ export const runPetalsCompletionRequest = async (
             // Merge content if needed
             if (lm) {
               if (lm.role === 'system' && m.role === 'user' && c.includes('[[SYSTEM_PROMPT]]')) {
-                console.log('do rep', lm, m)
                 c = c.replaceAll('[[SYSTEM_PROMPT]]', lm.content)
                 replace = true
               } else {
-                console.log('no rep', lm, m)
                 c = c.replaceAll('[[SYSTEM_PROMPT]]', '')
               }
               if (lm.role === 'user' && m.role === 'assistant' && c.includes('[[USER_PROMPT]]')) {
@@ -137,7 +135,6 @@ export const runPetalsCompletionRequest = async (
             }
             return a
           }, [] as Message[])
-          console.log('message debug', dupe, rMessages, inputArray)
           const leadPrompt = ((inputArray[inputArray.length - 1] || {}) as Message).role !== 'assistant' ? getLeadPrompt(chat) : ''
           const petalsRequest = {
             type: 'generate',

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -100,7 +100,6 @@ export const runPetalsCompletionRequest = async (
           const buildMessage = (m: Message): string => {
             return getRoleTag(m.role, model, chat) + m.content + getRoleEnd(m.role, model, chat)
           }
-          const dupe = JSON.parse(JSON.stringify(rMessages))
           const inputArray = rMessages.reduce((a, m, i) => {
             let c = buildMessage(m)
             let replace = false

--- a/src/lib/ChatRequestPetals.svelte
+++ b/src/lib/ChatRequestPetals.svelte
@@ -59,6 +59,7 @@ export const runPetalsCompletionRequest = async (
         }
         chatRequest.updating = false
         chatRequest.updatingMessage = ''
+        ws.close()
       })
       ws.onopen = () => {
         ws.send(JSON.stringify({

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -109,11 +109,17 @@ const defaults:ChatSettings = {
   hppContinuePrompt: '',
   hppWithSummaryPrompt: false,
   imageGenerationSize: '',
+  startSequence: '',
   stopSequence: '',
   aggressiveStop: false,
+  deliminator: '',
   userMessageStart: '',
+  userMessageEnd: '',
   assistantMessageStart: '',
+  assistantMessageEnd: '',
   systemMessageStart: '',
+  systemMessageEnd: '',
+  leadPrompt: '',
   // useResponseAlteration: false,
   // responseAlterations: [],
   isDirty: false
@@ -515,9 +521,20 @@ const chatSettingsList: ChatSetting[] = [
         hide: isNotOpenAI
       },
       {
+        key: 'startSequence',
+        name: 'Start Sequence',
+        title: 'Characters used to start the message chain.',
+        type: 'textarea',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).start
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
         key: 'stopSequence',
         name: 'Stop Sequence',
-        title: 'Characters used to separate messages in the message chain.',
+        title: 'Characters used to signal end of message chain.',
         type: 'text',
         placeholder: (chatId) => {
           const val = getModelDetail(getChatSettings(chatId).model).stop
@@ -533,12 +550,34 @@ const chatSettingsList: ChatSetting[] = [
         hide: isNotPetals
       },
       {
+        key: 'deliminator',
+        name: 'Deliminator Sequence',
+        title: 'Characters used to separate messages in the message chain.',
+        type: 'textarea',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).deliminator
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
         key: 'userMessageStart',
         name: 'User Message Start Sequence',
-        title: 'Sequence to denote user messages in the message chain.',
-        type: 'text',
+        title: 'Sequence to denote start of user messages in the message chain.',
+        type: 'textarea',
         placeholder: (chatId) => {
           const val = getModelDetail(getChatSettings(chatId).model).userStart
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'userMessageEnd',
+        name: 'User Message End Sequence',
+        title: 'Sequence to denote end of user messages in the message chain.',
+        type: 'textarea',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).userEnd
           return val || ''
         },
         hide: isNotPetals
@@ -547,9 +586,31 @@ const chatSettingsList: ChatSetting[] = [
         key: 'assistantMessageStart',
         name: 'Assistant Message Start Sequence',
         title: 'Sequence to denote assistant messages in the message chain.',
-        type: 'text',
+        type: 'textarea',
         placeholder: (chatId) => {
           const val = getModelDetail(getChatSettings(chatId).model).assistantStart
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'assistantMessageEnd',
+        name: 'Assistant Message End Sequence',
+        title: 'Sequence to denote end of assistant messages in the message chain.',
+        type: 'textarea',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).assistantEnd
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'leadPrompt',
+        name: 'Completion Lead Sequence ',
+        title: 'Sequence to hint the LLM should answer as assistant.',
+        type: 'textarea',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).leadPrompt
           return val || ''
         },
         hide: isNotPetals
@@ -558,9 +619,20 @@ const chatSettingsList: ChatSetting[] = [
         key: 'systemMessageStart',
         name: 'System Message Start Sequence',
         title: 'Sequence to denote system messages in the message chain.',
-        type: 'text',
+        type: 'textarea',
         placeholder: (chatId) => {
           const val = getModelDetail(getChatSettings(chatId).model).systemStart
+          return val || ''
+        },
+        hide: isNotPetals
+      },
+      {
+        key: 'systemMessageEnd',
+        name: 'System Message End Sequence',
+        title: 'Sequence to denote end of system messages in the message chain.',
+        type: 'textarea',
+        placeholder: (chatId) => {
+          const val = getModelDetail(getChatSettings(chatId).model).systemEnd
           return val || ''
         },
         hide: isNotPetals

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -12,10 +12,16 @@ export type RequestType = 'OpenAIChat' | 'OpenAIDall-e' | 'Petals'
 export type ModelDetail = {
     type: RequestType;
     label?: string;
+    start?: string;
     stop?: string[];
+    deliminator?: string;
     userStart?: string,
+    userEnd?: string,
     assistantStart?: string,
+    assistantEnd?: string,
     systemStart?: string,
+    systemEnd?: string,
+    leadPrompt?: string,
     prompt: number;
     completion: number;
     max: number;
@@ -113,11 +119,17 @@ export type ChatSettings = {
     trainingPrompts?: Message[];
     useResponseAlteration?: boolean;
     responseAlterations?: ResponseAlteration[];
+    startSequence: string;
     stopSequence: string;
     aggressiveStop: boolean;
+    deliminator: string;
     userMessageStart: string;
+    userMessageEnd: string;
     assistantMessageStart: string;
+    assistantMessageEnd: string;
+    leadPrompt: string;
     systemMessageStart: string;
+    systemMessageEnd: string;
     isDirty?: boolean;
   } & Request;
 


### PR DESCRIPTION
WebSocket connections were being left open for Petals API calls creating a new open connection for every request.  This is now fixed.
Llama-2-chat requests are new formatted to more closely follow what Meta trained it on:
https://huggingface.co/blog/llama2#how-to-prompt-llama-2

Also, this should be tested:
https://colab.research.google.com/drive/17Sn4AwrnHHN-lS1qoYltManEwgHOk-2d?usp=sharing

If it works out, it probably should be copied to GitHub and linked to in the webapp.
