### PR TITLE
Bugfix + add copy profile as URL to clipboard option

### DIFF
--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -35,6 +35,7 @@
   import { openModal } from 'svelte-modals'
   import PromptConfirm from './PromptConfirm.svelte'
   import { getChatModelOptions, getImageModelOptions } from './Models.svelte'
+  import { faClipboard } from '@fortawesome/free-regular-svg-icons'
 
   export let chatId:number
   export const show = () => { showSettings() }
@@ -97,6 +98,20 @@
     showSettingsModal && showSettings()
   }
   
+  const copySettingsAsUri = () => {
+    // location.protocol + '//' + location.host + location.pathname
+    const uri = '#/chat/new?petals=true&' + Object.entries(chatSettings).reduce((a, [k, v]) => {
+      const t = typeof v
+      if (t === 'boolean' || t === 'string' || t === 'number') {
+        a.push(encodeURI(k) + '=' + encodeURI(v as any))
+      }
+      return a
+    }, [] as string[]).join('&')
+    const profileUri = window.location.protocol + '//' + window.location.host + window.location.pathname + uri
+    navigator.clipboard.writeText(profileUri)
+    return profileUri
+  }
+
   const cloneProfile = () => {
     showProfileMenu = false
     const clone = JSON.parse(JSON.stringify(chat.settings))
@@ -311,6 +326,9 @@
                 </a>
                 <a href={'#'} class="dropdown-item" on:click|preventDefault={() => { showProfileMenu = false; profileFileInput.click() }}>
                   <span class="menu-icon"><Fa icon={faUpload}/></span> Restore Profile JSON
+                </a>
+                <a href={'#'} class="dropdown-item" on:click|preventDefault={() => { showProfileMenu = false; copySettingsAsUri() }}>
+                  <span class="menu-icon"><Fa icon={faClipboard}/></span> Copy Profile URL to Clipboard
                 </a>
                 <hr class="dropdown-divider">
                 <a href={'#'} class="dropdown-item" on:click|preventDefault={promptDeleteProfile}>

--- a/src/lib/NewChat.svelte
+++ b/src/lib/NewChat.svelte
@@ -2,7 +2,7 @@
   import { querystring } from 'svelte-spa-router'
   import { addChat, setChatSettingValueByKey } from './Storage.svelte'
   import { replace } from 'svelte-spa-router'
-  import { getProfile } from './Profiles.svelte'
+  import { getProfile, restartProfile } from './Profiles.svelte'
   import { getChatDefaults } from './Settings.svelte'
 
   // Create the new chat instance then redirect to it
@@ -14,6 +14,7 @@
       setChatSettingValueByKey(chatId, k as any, urlParams.get(k))
     }
   })
-
+  
+  restartProfile(chatId)
   replace(`/chat/${chatId}`)
 </script>


### PR DESCRIPTION
- Fix issue where some profile settings pulled from url parameters were not applied.
- Add copy profile as URL to clipboard option. Allows sharing basic profile settings via url parameters.
