### PR TITLE
Added DALL-E models and gpt-4-1106-preview

### DIFF
--- a/src/lib/providers/openai/models.svelte
+++ b/src/lib/providers/openai/models.svelte
@@ -81,6 +81,12 @@ const gpt432k = {
       completion: 0.00012, // $0.12 per 1000 tokens completion
       max: 32768 // 32k max token buffer
 }
+const gpt4120kpreview = {
+      ...chatModelBase,
+      prompt: 0.00003, // $0.03 per 1000 tokens prompt
+      completion: 0.00006, // $0.06 per 1000 tokens completion
+      max: 128000 // 128k max token buffer
+}
 
 export const chatModels : Record<string, ModelDetail> = {
   'gpt-3.5-turbo': { ...gpt35 },
@@ -90,6 +96,7 @@ export const chatModels : Record<string, ModelDetail> = {
   'gpt-4': { ...gpt4 },
   'gpt-4-0314': { ...gpt4 },
   'gpt-4-0613': { ...gpt4 },
+  'gpt-4-1106-preview': {...gpt4120kpreview},
   'gpt-4-32k': { ...gpt432k },
   'gpt-4-32k-0314': { ...gpt432k },
   'gpt-4-32k-0613': { ...gpt432k }
@@ -127,6 +134,63 @@ export const imageModels : Record<string, ModelDetail> = {
         completion: 0.016, // $0.016 per image
         opt: {
           size: '256x256'
+        }
+      },
+      'dall-e-3-1024x1024': {
+        ...imageModelBase,
+        type: 'image',
+        completion: 0.04, // $0.040 per image
+        opt: {
+          model: 'dall-e-3',
+          size: '1024x1024'
+        }
+      },
+      'dall-e-3-1024x1792-Portrait': {
+        ...imageModelBase,
+        type: 'image',
+        completion: 0.08, // $0.080 per image
+        opt: {
+          model: 'dall-e-3',
+          size: '1024x1792'
+        }
+      },
+      'dall-e-3-1792x1024-Landscape': {
+        ...imageModelBase,
+        type: 'image',
+        completion: 0.08, // $0.080 per image
+        opt: {
+          model: 'dall-e-3',
+          size: '1792x1024'
+        }
+      },
+      'dall-e-3-1024x1024-HD': {
+        ...imageModelBase,
+        type: 'image',
+        completion: 0.08, // $0.080 per image
+        opt: {
+          model: 'dall-e-3',
+          size: '1024x1024',
+          quality: 'hd'
+        }
+      },
+      'dall-e-3-1024x1792-Portrait-HD': {
+        ...imageModelBase,
+        type: 'image',
+        completion: 0.12, // $0.080 per image
+        opt: {
+          model: 'dall-e-3',
+          size: '1024x1792',
+          quality: 'hd'
+        }
+      },
+      'dall-e-3-1792x1024-Landscape-HD': {
+        ...imageModelBase,
+        type: 'image',
+        completion: 0.12, // $0.080 per image
+        opt: {
+          model: 'dall-e-3',
+          size: '1792x1024',
+          quality: 'hd'
         }
       }
 }

--- a/src/lib/providers/openai/models.svelte
+++ b/src/lib/providers/openai/models.svelte
@@ -96,7 +96,7 @@ export const chatModels : Record<string, ModelDetail> = {
   'gpt-4': { ...gpt4 },
   'gpt-4-0314': { ...gpt4 },
   'gpt-4-0613': { ...gpt4 },
-  'gpt-4-1106-preview': {...gpt4120kpreview},
+  'gpt-4-1106-preview': { ...gpt4120kpreview },
   'gpt-4-32k': { ...gpt432k },
   'gpt-4-32k-0314': { ...gpt432k },
   'gpt-4-32k-0613': { ...gpt432k }

--- a/src/lib/providers/openai/request.svelte
+++ b/src/lib/providers/openai/request.svelte
@@ -121,18 +121,17 @@ export const imageRequest = async (
   const imageModel = chatSettings.imageGenerationModel
   const imageModelDetail = getModelDetail(imageModel)
   const size = imageModelDetail.opt?.size || '256x256'
-  const model = imageModelDetail.opt?.model;
-  const style = imageModelDetail.opt?.style;
-  const quality = imageModelDetail.opt?.quality;
+  const model = imageModelDetail.opt?.model
+  const style = imageModelDetail.opt?.style
+  const quality = imageModelDetail.opt?.quality
   const request: RequestImageGeneration = {
         prompt,
         response_format: 'b64_json',
         size,
         n: count,
-        // Include these parameters if specified in the image model
-        ...(model ? { model } :{}),
-        ...(style ? { style } :{}),
-        ...(quality ? { quality } :{})
+        ...(model ? { model } : {}),
+        ...(style ? { style } : {}),
+        ...(quality ? { quality } : {})
   }
   // fetchEventSource doesn't seem to throw on abort,
   // so we deal with it ourselves

--- a/src/lib/providers/openai/request.svelte
+++ b/src/lib/providers/openai/request.svelte
@@ -102,6 +102,9 @@ type RequestImageGeneration = {
     n?: number;
     size?: string;
     response_format?: keyof ResponseImageDetail;
+    model?: string;
+    quality?: string;
+    style?: string;
   }
 
 export const imageRequest = async (
@@ -118,11 +121,18 @@ export const imageRequest = async (
   const imageModel = chatSettings.imageGenerationModel
   const imageModelDetail = getModelDetail(imageModel)
   const size = imageModelDetail.opt?.size || '256x256'
+  const model = imageModelDetail.opt?.model;
+  const style = imageModelDetail.opt?.style;
+  const quality = imageModelDetail.opt?.quality;
   const request: RequestImageGeneration = {
         prompt,
         response_format: 'b64_json',
         size,
-        n: count
+        n: count,
+        // Include these parameters if specified in the image model
+        ...(model ? { model } :{}),
+        ...(style ? { style } :{}),
+        ...(quality ? { quality } :{})
   }
   // fetchEventSource doesn't seem to throw on abort,
   // so we deal with it ourselves


### PR DESCRIPTION
Added the following image generation models with prices:

DALL-E 3: 1024x1024, 1024x1792 (Portrait), 1792x1024 (Landscape).

Added DALL-E 3 options for the above sizes where quality=hd.

Added updated GPT-4 Turbo model: gpt-4-1106-preview