### PR TITLE
Fix docker build error

### DIFF
--- a/mocked_api/Dockerfile-mockapi
+++ b/mocked_api/Dockerfile-mockapi
@@ -1,6 +1,7 @@
 FROM python:3.10.10-alpine3.17
 WORKDIR /work
 
+RUN pip install --upgrade pip
 RUN pip install "fastapi<1.0" "uvicorn<0.22" "lorem-text<=2.1.x"
 COPY mocked_api/mock_api.py .
 COPY mocked_api/models_response.json .


### PR DESCRIPTION
Docker build fails with error:
FileNotFoundError: [Errno 2] No such file or directory: 'README.md'