### PR TITLE
Show gpt model in placeholder text

### DIFF
--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -401,7 +401,7 @@
     <p class="control is-expanded">
       <textarea
         class="input is-info is-focused chat-input auto-size"
-        placeholder="Type your message here..."
+        placeholder="[{chat.settings.model}] Type your message here..."
         rows="1"
         on:keydown={e => {
           // Only send if Enter is pressed, not Shift+Enter


### PR DESCRIPTION
Show what gpt model will be used for the current profile. 
The profile system is a very good idea but this annoyed me quite a lot. I think a lot of people might accidently end up using gpt-3.5 and not be aware of it. Now its clear what model will be used for the request.

![image](https://github.com/Niek/chatgpt-web/assets/40603805/1a9eb7e7-c56f-4433-8dce-5fc7b16d2dd8)

