### PR TITLE
feat: add OrcaRouter as a provider preset for OpenAI-compatible endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,7 @@
 #VITE_ENDPOINT_COMPLETIONS=/v1/chat/completions
 #VITE_ENDPOINT_MODELS=/v1/models
 #VITE_OPENAI_API_KEY="your-openai-api-key"
+
+# To use OrcaRouter as the API provider instead:
+#VITE_API_BASE=https://api.orcarouter.ai/v1
+#VITE_OPENAI_API_KEY="sk-orca-..."

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ For instances where immediate API responses are preferred, consider utilizing th
   * To specify the length of the response, use `l` followed by the desired number of sentences (e.g., `l10` for a response of 10 sentences).
   * For instance, sending `d2 l10` configures the mocked API to delay the response by 2 seconds and to include 10 sentences.
 
+## Using OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key, with gateway-level security controls for AI agents.
+
+To use it:
+
+1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
+2. On the home screen, choose **OrcaRouter** from the "Provider preset" dropdown (or enter `https://api.orcarouter.ai` as the API BASE URI) and paste your key.
+3. Pick any model exposed by the gateway in a chat (e.g. `orcarouter/auto`, `deepseek/deepseek-v4-flash`, `openai/gpt-4o`).
+
+Alternatively, set it via the `.env` file:
+
+```
+VITE_API_BASE=https://api.orcarouter.ai/v1
+VITE_OPENAI_API_KEY="sk-orca-..."
+```
+
 ## Desktop app
 
 To use ChatGPT-web as a desktop application:

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -57,6 +57,25 @@
       return false
     }
   }
+
+  // Named presets for OpenAI-compatible API endpoints.  Choosing one
+  // validates the endpoint the same way the "Save" button does.
+  const endpointPresets: Record<string, string> = {
+    openai: 'https://api.openai.com',
+    orcarouter: 'https://api.orcarouter.ai'
+  }
+
+  let endpointPreset = ''
+
+  const applyEndpointPreset = async (event: Event) => {
+    const preset = (event.target as HTMLSelectElement).value
+    endpointPreset = ''
+    if (!preset) return
+    const baseUri = endpointPresets[preset]
+    if (await testApiEndpoint(baseUri)) {
+      setGlobalSettingValueByKey('openAiEndpoint', baseUri)
+    }
+  }
 </script>
 
 <section class="section">
@@ -122,6 +141,16 @@
   <article class="message" class:is-danger={!hasModels || apiError} class:is-warning={!openAiEndpoint} class:is-info={openAiEndpoint && !apiError}>
     <div class="message-body">
       Set the API BASE URI for alternative OpenAI-compatible endpoints:
+      <div class="field my-3">
+        <label class="label" for="apiEndpointPreset">Provider preset</label>
+        <div class="select">
+          <select id="apiEndpointPreset" bind:value={endpointPreset} on:change={applyEndpointPreset}>
+            <option value="">Custom...</option>
+            <option value="openai">OpenAI</option>
+            <option value="orcarouter">OrcaRouter</option>
+          </select>
+        </div>
+      </div>
       <form
         class="field has-addons has-addons-right"
         on:submit|preventDefault={async (event) => {


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider preset in ChatGPT-web. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key, with gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/lib/Home.svelte`: adds an **OrcaRouter** entry to a new "Provider preset" dropdown in the API BASE URI card. Picking a preset validates the endpoint with the existing `testApiEndpoint` check and saves it, so users no longer need to type the base URI by hand.
- `README.md`: adds a "Using OrcaRouter" section (how to get a key, pick the preset, choose a model).
- `.env`: documents the `VITE_API_BASE` / `VITE_OPENAI_API_KEY` values for OrcaRouter.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. On the home screen, choose **OrcaRouter** from the "Provider preset" dropdown and paste your key.
3. Pick any model exposed by the gateway in a chat (e.g. `orcarouter/auto`, `deepseek/deepseek-v4-flash`, `openai/gpt-4o`).

Or set the base URI via `.env`:

```
VITE_API_BASE=https://api.orcarouter.ai/v1
VITE_OPENAI_API_KEY="sk-orca-..."
```

## Verification

- `npm run check` (svelte-check) — no errors.
- `npm run build` (vite build) — succeeds.
- Live API check: `GET https://api.orcarouter.ai/v1/models` and `POST https://api.orcarouter.ai/v1/chat/completions` (the exact URLs this app builds via `getApiBase() + '/v1/models'` and `+ '/v1/chat/completions'`) both return 200 with a real completion.
