### PR TITLE
Revamp image generation provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ChatGPT-web is a simple one-page web interface for OpenAI-compatible chat APIs. 
 * **Export**: ChatGPT-web can export chats as a Markdown file, so you can share them with others.
 * **Code**: ChatGPT-web recognizes and highlights code blocks and allows you to copy them with one click.
 * **Desktop app**: ChatGPT-web can be bundled as a desktop app, so you can use it outside of the browser.
-* **Image generation**: Generate images through OpenAI, xAI, Google Gemini, OpenRouter, or a compatible custom endpoint by entering a provider model ID and prompting "show me an image of ...".
+* **Image generation**: Generate images through OpenAI, xAI, Google Gemini, OpenRouter, or a compatible custom endpoint by prompting "show me an image of ...".
 * **Streaming**: ChatGPT-web can stream the response from the API, so you can see the response as it's being generated.
 
 ## Supported providers

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ChatGPT-web is a simple one-page web interface for OpenAI-compatible chat APIs. 
 * **Export**: ChatGPT-web can export chats as a Markdown file, so you can share them with others.
 * **Code**: ChatGPT-web recognizes and highlights code blocks and allows you to copy them with one click.
 * **Desktop app**: ChatGPT-web can be bundled as a desktop app, so you can use it outside of the browser.
-* **Image generation**: With OpenAI (or a compatible custom endpoint), ChatGPT-web can generate images using the DALL·E model by using the prompt "show me an image of ...".
+* **Image generation**: Generate images through OpenAI, xAI, Google Gemini, OpenRouter, or a compatible custom endpoint by entering a provider model ID and prompting "show me an image of ...".
 * **Streaming**: ChatGPT-web can stream the response from the API, so you can see the response as it's being generated.
 
 ## Supported providers
@@ -42,6 +42,8 @@ The setup screen has presets for:
 * Any custom OpenAI-compatible API
 
 Anthropic's compatibility layer is intended primarily for testing and comparison. Some OpenAI request fields are ignored or translated; see [Anthropic's compatibility documentation](https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk) for the current limitations.
+
+Image generation is available for providers with a compatible image endpoint. In chat settings, enter an image model ID such as `gpt-image-2` for OpenAI, `grok-imagine-image-quality` for xAI, or `gemini-2.5-flash-image` for Google Gemini. Leave the field blank to disable image generation.
 
 ## Development and Building
 
@@ -100,6 +102,7 @@ For instances where immediate API responses are preferred, consider utilizing th
   * Assign the key `VITE_API_BASE=http://localhost:5174` to redirect requests to the mocked API.
   * Assign any non-empty value to `VITE_API_KEY`.
   * Execute `docker compose up -d mocked_api` to start the mocked API service.
+  * To test image generation, set the chat's Image Generation Model to `mock-image` and prompt "show me an image of ...".
 
 * **Customizing Responses**:
   * To introduce a delay in the API response, use `d` followed by the desired number of seconds (e.g., `d2` for a 2-second delay).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The setup screen has presets for:
 
 Anthropic's compatibility layer is intended primarily for testing and comparison. Some OpenAI request fields are ignored or translated; see [Anthropic's compatibility documentation](https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk) for the current limitations.
 
-Image generation is available for providers with a compatible image endpoint. In chat settings, enter an image model ID such as `gpt-image-2` for OpenAI, `grok-imagine-image-quality` for xAI, or `gemini-2.5-flash-image` for Google Gemini. Leave the field blank to disable image generation.
+Image generation is available for providers with a compatible image endpoint. ChatGPT-web automatically uses the provider default, such as `gpt-image-2` for OpenAI, `grok-imagine-image-quality` for xAI, or `gemini-2.5-flash-image` for Google Gemini. The chat setting can override that default; providers without a known default require an explicit model ID.
 
 ## Development and Building
 
@@ -103,6 +103,7 @@ For instances where immediate API responses are preferred, consider utilizing th
   * Assign any non-empty value to `VITE_API_KEY`.
   * Execute `docker compose up -d mocked_api` to start the mocked API service.
   * To test image generation, set the chat's Image Generation Model to `mock-image` and prompt "show me an image of ...".
+  * To test safe inline SVG rendering, prompt `mock svg` without enabling image generation.
 
 * **Customizing Responses**:
   * To introduce a delay in the API response, use `d` followed by the desired number of seconds (e.g., `d2` for a 2-second delay).

--- a/mocked_api/mock_api.py
+++ b/mocked_api/mock_api.py
@@ -5,6 +5,7 @@ from lorem_text import lorem
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 
 app = FastAPI()
 
@@ -17,6 +18,35 @@ app.add_middleware(
 )
 
 MOCK_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XSn1WQAAAABJRU5ErkJggg=="
+
+
+def stream_chat_completion(answer: str, model: str):
+    """Yield a deterministic OpenAI-compatible SSE response."""
+    chunk_size = 8
+    for offset in range(0, len(answer), chunk_size):
+        chunk = {
+            "id": "mock-stream",
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "finish_reason": None,
+                "delta": {"content": answer[offset:offset + chunk_size]},
+            }],
+        }
+        yield f"data: {json.dumps(chunk)}\n\n"
+        time.sleep(0.08)
+
+    finished = {
+        "id": "mock-stream",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "finish_reason": "stop",
+            "delta": {},
+        }],
+    }
+    yield f"data: {json.dumps(finished)}\n\n"
+    yield "data: [DONE]\n\n"
 
 
 # Define a route to handle POST requests
@@ -49,7 +79,16 @@ async def post_data(data: dict):
         answer = "\n".join([lorem.sentence() for _ in range(int(lines))])
 
     if 'mock svg' in instructions.lower():
-        answer = '<svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg"><rect width="320" height="180" rx="24" fill="#74aa9c"/><circle cx="92" cy="90" r="48" fill="#f4d06f"/><text x="160" y="100" fill="#102a2a" font-size="24" font-family="sans-serif">SVG rendered</text></svg>'
+        answer = 'Here is the SVG:\n\n<svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg"><rect width="320" height="180" rx="24" fill="#74aa9c"/><circle cx="92" cy="90" r="48" fill="#f4d06f"/><text x="160" y="100" fill="#102a2a" font-size="24" font-family="sans-serif">SVG rendered</text></svg>'
+
+    if 'mock html' in instructions.lower():
+        answer = 'Here is the HTML:\n\n<div><strong>HTML rendered</strong><p>Streaming markup stayed stable.</p></div>'
+
+    if data.get('stream'):
+        return StreamingResponse(
+            stream_chat_completion(answer, data.get('model', 'mock-model')),
+            media_type='text/event-stream',
+        )
 
     response = {
         "id": 0,

--- a/mocked_api/mock_api.py
+++ b/mocked_api/mock_api.py
@@ -48,6 +48,9 @@ async def post_data(data: dict):
     if lines:
         answer = "\n".join([lorem.sentence() for _ in range(int(lines))])
 
+    if 'mock svg' in instructions.lower():
+        answer = '<svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg"><rect width="320" height="180" rx="24" fill="#74aa9c"/><circle cx="92" cy="90" r="48" fill="#f4d06f"/><text x="160" y="100" fill="#102a2a" font-size="24" font-family="sans-serif">SVG rendered</text></svg>'
+
     response = {
         "id": 0,
         "choices": [{

--- a/mocked_api/mock_api.py
+++ b/mocked_api/mock_api.py
@@ -16,6 +16,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+MOCK_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XSn1WQAAAABJRU5ErkJggg=="
+
 
 # Define a route to handle POST requests
 @app.post("/v1/chat/completions")
@@ -55,6 +57,28 @@ async def post_data(data: dict):
         }]
     }
     return response
+
+
+@app.post("/v1/images/generations")
+@app.post("/v1/images")
+async def generate_images(data: dict):
+    """Returns base64-encoded mock images for compatible image endpoints."""
+    count = max(1, min(int(data.get("n", 1)), 4))
+    return {
+        "created": int(time.time()),
+        "data": [
+            {
+                "b64_json": MOCK_IMAGE_B64,
+                "media_type": "image/png",
+            }
+            for _ in range(count)
+        ],
+        "usage": {
+            "input_tokens": 1,
+            "output_tokens": count,
+            "total_tokens": count + 1,
+        },
+    }
 
 
 @app.get('/v1/models')

--- a/src/app.scss
+++ b/src/app.scss
@@ -602,6 +602,12 @@ aside.menu.main-menu .menu-expanse {
   min-width: 60px;
   min-height: 1.3em;
 }
+.message-display .generated-svg {
+  display: block;
+  width: 640px;
+  max-width: 100%;
+  height: auto;
+}
 .button-pack {
   display: block;
   position: sticky;

--- a/src/lib/ApiUtil.svelte
+++ b/src/lib/ApiUtil.svelte
@@ -4,8 +4,8 @@
   // Environment overrides remain useful for custom OpenAI-compatible APIs.
   export const getEndpointCompletions = (providerId: ProviderId):string =>
     import.meta.env.VITE_ENDPOINT_COMPLETIONS || getProvider(providerId).endpoints.completions
-  export const getEndpointGenerations = (providerId: ProviderId):string =>
-    import.meta.env.VITE_ENDPOINT_GENERATIONS || getProvider(providerId).endpoints.generations
+  export const getImageEndpoint = (providerId: ProviderId):string | undefined =>
+    import.meta.env.VITE_ENDPOINT_GENERATIONS || getProvider(providerId).image?.endpoint
   export const getEndpointModels = (providerId: ProviderId):string =>
     import.meta.env.VITE_ENDPOINT_MODELS || getProvider(providerId).endpoints.models
   export const getEndpointEmbeddings = (providerId: ProviderId):string =>

--- a/src/lib/ChatCompletionResponse.svelte
+++ b/src/lib/ChatCompletionResponse.svelte
@@ -3,7 +3,7 @@ import { setImage } from './ImageStore.svelte'
 import { countTokens, getModelDetail } from './Models.svelte'
 // TODO: Integrate API calls
 import { addMessage, getLatestKnownModel, setLatestKnownModel, subtractRunningTotal, updateMessages, updateRunningTotal } from './Storage.svelte'
-import type { Chat, ChatCompletionOpts, ChatImage, Message, Model, Response, Usage } from './Types.svelte'
+import type { Chat, ChatCompletionOpts, ChatImage, GeneratedImage, Message, Model, Response, Usage } from './Types.svelte'
 import { v4 as uuidv4 } from 'uuid'
 
 export class ChatCompletionResponse {
@@ -69,21 +69,18 @@ export class ChatCompletionResponse {
     return this.promptTokenCount
   }
 
-  async updateImageFromSyncResponse (images: string[], prompt: string, model: Model) {
-    this.setModel(model)
+  async updateImageFromSyncResponse (images: GeneratedImage[], prompt: string, model: Model, usage: Usage) {
+    this.model = model
     for (let i = 0; i < images.length; i++) {
-      const b64image = images[i]
       const message = {
         role: 'image',
         uuid: uuidv4(),
         content: prompt,
-        image: await setImage(this.chat.id, { b64image } as ChatImage),
+        image: await setImage(this.chat.id, images[i] as ChatImage),
         model,
-        usage: {
-          prompt_tokens: 0,
-          completion_tokens: 1,
-          total_tokens: 1
-        } as Usage
+        usage: i === 0
+          ? { ...usage }
+          : { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
       } as Message
       this.messages[i] = message
       if (this.opts.autoAddMessages) addMessage(this.chat.id, message)

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -18,6 +18,7 @@
     import { v4 as uuidv4 } from 'uuid'
     import { get } from 'svelte/store'
     import { getLeadPrompt, getModelDetail } from './Models.svelte'
+    import { imageRequest } from './providers/openai/request.svelte'
 
 export class ChatRequest {
       constructor () {
@@ -94,7 +95,7 @@ export class ChatRequest {
           }
         }
 
-        if (chatSettings.imageGenerationModel && !opts.didSummary && !opts.summaryRequest && lastMessage?.role === 'user') {
+        if (chatSettings.imageGenerationModel.trim() && !opts.didSummary && !opts.summaryRequest && lastMessage?.role === 'user') {
           const im = lastMessage.content.match(imagePromptDetect)
           if (im) {
             let n = parseInt((im[5] || '').toLowerCase().trim()
@@ -107,8 +108,7 @@ export class ChatRequest {
             n = Math.min(Math.max(1, n), 4)
             lastMessage.suppress = true
 
-            const imageModelDetail = getModelDetail(chatSettings.imageGenerationModel)
-            return await imageModelDetail.request({} as unknown as Request, _this, chatResponse, {
+            return await imageRequest(_this, chatResponse, {
               ...opts,
               prompt: im[9],
               count: n

--- a/src/lib/ChatRequest.svelte
+++ b/src/lib/ChatRequest.svelte
@@ -12,13 +12,14 @@
     import { cleanContent, mergeProfileFields, prepareSummaryPrompt } from './Profiles.svelte'
     import { countMessageTokens, countPromptTokens, getModelMaxTokens } from './Stats.svelte'
     import type { Chat, ChatCompletionOpts, ChatSettings, Message, Model, Request } from './Types.svelte'
-    import { deleteMessage, getChatSettingValueNullDefault, insertMessages, addError, currentChatMessages, getMessages, updateMessages, deleteSummaryMessage, getChat } from './Storage.svelte'
+    import { deleteMessage, getChatSettingValueNullDefault, getProviderId, insertMessages, addError, currentChatMessages, getMessages, updateMessages, deleteSummaryMessage, getChat } from './Storage.svelte'
     import { scrollToBottom, scrollToMessage } from './Util.svelte'
     import { getDefaultModel, getRequestSettingList } from './Settings.svelte'
     import { v4 as uuidv4 } from 'uuid'
     import { get } from 'svelte/store'
     import { getLeadPrompt, getModelDetail } from './Models.svelte'
     import { imageRequest } from './providers/openai/request.svelte'
+    import { resolveImageModel } from './providers/openai/providers'
 
 export class ChatRequest {
       constructor () {
@@ -76,7 +77,7 @@ export class ChatRequest {
         await this.setChat(chat)
         const chatSettings = _this.chat.settings
         const chatId = chat.id
-        const imagePromptDetect = /^\s*(please|can\s+you|will\s+you)*\s*(give|generate|create|show|build|design)\s+(me)*\s*(an|a|set|a\s+set\s+of)*\s*([0-9]+|one|two|three|four)*\s+(image|photo|picture|pic)s*\s*(for\s+me)*\s*(of|[^a-z0-9]+|about|that\s+has|showing|with|having|depicting)\s+[^a-z0-9]*(.*)$/i
+        const imagePromptDetect = /^\s*(please|can\s+you|will\s+you)*\s*(give|generate|create|show|build|design|make)\s+(me)*\s*(an|a|set|a\s+set\s+of)*\s*([0-9]+|one|two|three|four)*\s+(image|photo|picture|pic)s*\s*(for\s+me)*\s*(of|[^a-z0-9]+|about|that\s+has|showing|with|having|depicting)\s+[^a-z0-9]*(.*)$/i
         opts.chat = chat
         _this.updating = true
 
@@ -95,7 +96,7 @@ export class ChatRequest {
           }
         }
 
-        if (chatSettings.imageGenerationModel.trim() && !opts.didSummary && !opts.summaryRequest && lastMessage?.role === 'user') {
+        if (resolveImageModel(getProviderId(), chatSettings.imageGenerationModel) && !opts.didSummary && !opts.summaryRequest && lastMessage?.role === 'user') {
           const im = lastMessage.content.match(imagePromptDetect)
           if (im) {
             let n = parseInt((im[5] || '').toLowerCase().trim()

--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -33,7 +33,7 @@
   import { replace } from 'svelte-spa-router'
   import { openModal } from 'svelte-modals/legacy'
   import PromptConfirm from './PromptConfirm.svelte'
-  import { getChatModelOptions, getImageModelOptions } from './Models.svelte'
+  import { getChatModelOptions } from './Models.svelte'
   import { faClipboard } from '@fortawesome/free-regular-svg-icons'
   import { clickOutside } from 'svelte-use-click-outside'
 
@@ -48,7 +48,6 @@
 
   const settingsList = getChatSettingList()
   const modelSetting = getChatSettingObjectByKey('model') as ChatSetting & SettingSelect
-  const imageModelSetting = getChatSettingObjectByKey('imageGenerationModel') as ChatSetting & SettingSelect
   const chatDefaults = getChatDefaults()
   const excludeFromProfile = getExcludeFromProfile()
 
@@ -204,7 +203,6 @@
     // Update the models in the settings
     if (modelSetting) {
       modelSetting.options = await getChatModelOptions()
-      imageModelSetting.options = await getImageModelOptions()
     }
     // Refresh settings modal
     showSettingsModal++

--- a/src/lib/ChatSettingsModal.svelte
+++ b/src/lib/ChatSettingsModal.svelte
@@ -29,7 +29,6 @@
   import { exportProfileAsJSON } from './Export.svelte'
   import { onMount, afterUpdate } from 'svelte'
   import ChatSettingField from './ChatSettingField.svelte'
-  import { getModelMaxTokens } from './Stats.svelte'
   import { replace } from 'svelte-spa-router'
   import { openModal } from 'svelte-modals/legacy'
   import PromptConfirm from './PromptConfirm.svelte'
@@ -184,7 +183,6 @@
     const profileSelect = getChatSettingObjectByKey('profile') as ChatSetting & SettingSelect
     profileSelect.options = await getProfileSelect()
     chatDefaults.profile = await getDefaultProfileKey()
-    chatDefaults.max_completion_tokens = getModelMaxTokens(chatSettings.model)
     defaultProfile = await getDefaultProfileKey()
     isDefault = defaultProfile === chatSettings.profile
   }

--- a/src/lib/EditMessage.svelte
+++ b/src/lib/EditMessage.svelte
@@ -40,8 +40,82 @@
   type DisplayPart =
     | { type: 'markdown'; content: string }
     | { type: 'svg'; content: string }
+    | { type: 'pending'; content: string }
 
   const svgBlockPattern = /(?:```(?:svg|xml)?\s*)?(<svg\b[\s\S]*?<\/svg\s*>)(?:\s*```)?/gi
+  const voidHtmlElements = new Set([
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+    'link', 'meta', 'param', 'source', 'track', 'wbr'
+  ])
+
+  const findUnclosedMarkup = (content: string): { index: number; svg: boolean } | undefined => {
+    const stack: { name: string; index: number }[] = []
+    let index = 0
+
+    while (index < content.length) {
+      const tagIndex = content.indexOf('<', index)
+      if (tagIndex < 0) break
+
+      if (content.startsWith('<!--', tagIndex)) {
+        const commentEnd = content.indexOf('-->', tagIndex + 4)
+        if (commentEnd < 0) {
+          return { index: stack[0]?.index ?? tagIndex, svg: stack.some(tag => tag.name === 'svg') }
+        }
+        index = commentEnd + 3
+        continue
+      }
+
+      const tagMatch = content.slice(tagIndex).match(/^<\/?([a-z][\w:-]*)/i)
+      if (!tagMatch) {
+        const suffix = content.slice(tagIndex)
+        if (/^<(?:\/?)$/.test(suffix) || (/^<(?:!|\?)/.test(suffix) && !suffix.includes('>'))) {
+          return { index: stack[0]?.index ?? tagIndex, svg: stack.some(tag => tag.name === 'svg') }
+        }
+        index = tagIndex + 1
+        continue
+      }
+
+      const tagRemainder = content.slice(tagIndex + tagMatch[0].length)
+      if (tagRemainder && !/^(?:\s|>|\/(?:\s*>|\s*$))/.test(tagRemainder)) {
+        index = tagIndex + 1
+        continue
+      }
+
+      let quote = ''
+      let tagEnd = -1
+      for (let cursor = tagIndex + tagMatch[0].length; cursor < content.length; cursor++) {
+        const character = content[cursor]
+        if (quote) {
+          if (character === quote) quote = ''
+        } else if (character === '"' || character === "'") {
+          quote = character
+        } else if (character === '>') {
+          tagEnd = cursor
+          break
+        }
+      }
+
+      const name = tagMatch[1].toLowerCase()
+      if (tagEnd < 0) {
+        return {
+          index: stack[0]?.index ?? tagIndex,
+          svg: name === 'svg' || stack.some(tag => tag.name === 'svg')
+        }
+      }
+
+      const tag = content.slice(tagIndex, tagEnd + 1)
+      if (tag.startsWith('</')) {
+        const openIndex = stack.map(openTag => openTag.name).lastIndexOf(name)
+        if (openIndex >= 0) stack.splice(openIndex)
+      } else if (!/\/\s*>$/.test(tag) && !voidHtmlElements.has(name)) {
+        stack.push({ name, index: tagIndex })
+      }
+      index = tagEnd + 1
+    }
+
+    if (!stack.length) return
+    return { index: stack[0].index, svg: stack.some(tag => tag.name === 'svg') }
+  }
 
   const svgDataUrl = (source: string): string => {
     const sanitized = String(DOMPurify.sanitize(source, {
@@ -53,22 +127,29 @@
     return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sanitized)}`
   }
 
-  const buildDisplayParts = (content: string): DisplayPart[] => {
+  const buildDisplayParts = (content: string, streaming: boolean): DisplayPart[] => {
     if (!isAssistant) return [{ type: 'markdown', content }]
 
+    const pendingMarkup = streaming ? findUnclosedMarkup(content) : undefined
+    const renderableContent = pendingMarkup
+      ? content.slice(0, pendingMarkup.index).replace(/```(?:html|svg|xml)?\s*$/i, '')
+      : content
     const parts: DisplayPart[] = []
     let offset = 0
-    for (const match of content.matchAll(svgBlockPattern)) {
+    for (const match of renderableContent.matchAll(svgBlockPattern)) {
       const index = match.index || 0
-      if (index > offset) parts.push({ type: 'markdown', content: content.slice(offset, index) })
+      if (index > offset) parts.push({ type: 'markdown', content: renderableContent.slice(offset, index) })
       const image = svgDataUrl(match[1])
       parts.push(image
         ? { type: 'svg', content: image }
         : { type: 'markdown', content: match[0] })
       offset = index + match[0].length
     }
-    if (offset < content.length) parts.push({ type: 'markdown', content: content.slice(offset) })
-    return parts.length ? parts : [{ type: 'markdown', content }]
+    if (offset < renderableContent.length) parts.push({ type: 'markdown', content: renderableContent.slice(offset) })
+    if (pendingMarkup) {
+      parts.push({ type: 'pending', content: pendingMarkup.svg ? 'Rendering SVG…' : 'Receiving markup…' })
+    }
+    return parts.length ? parts : [{ type: 'markdown', content: renderableContent }]
   }
 
   const getDisplayMessage = ():string => {
@@ -87,13 +168,16 @@
   let imageUrl:string
   let refreshCounter = 0
   let renderedContent:string
+  let renderedStreaming:boolean
   let displayParts:DisplayPart[] = []
 
   const updateDisplayParts = () => {
     const content = getDisplayMessage()
-    if (content === renderedContent) return
+    const streaming = Boolean(message.streaming)
+    if (content === renderedContent && streaming === renderedStreaming) return
     renderedContent = content
-    displayParts = buildDisplayParts(content)
+    renderedStreaming = streaming
+    displayParts = buildDisplayParts(content, streaming)
   }
 
   onMount(() => {
@@ -322,6 +406,8 @@
         {#each displayParts as part}
           {#if part.type === 'svg'}
             <img class="generated-svg" src={part.content} alt="Generated SVG">
+          {:else if part.type === 'pending'}
+            <p class="streaming-markup">{part.content}</p>
           {:else}
             <SvelteMarkdown
               source={part.content}

--- a/src/lib/EditMessage.svelte
+++ b/src/lib/EditMessage.svelte
@@ -12,6 +12,7 @@
   import PromptConfirm from './PromptConfirm.svelte'
   import { getImage } from './ImageStore.svelte'
   import { getModelDetail } from './Models.svelte'
+  import DOMPurify from 'dompurify'
 
   export let message:Message
   export let chatId:number
@@ -36,6 +37,40 @@
     html: buildUnsupportedHTML()
   }
 
+  type DisplayPart =
+    | { type: 'markdown'; content: string }
+    | { type: 'svg'; content: string }
+
+  const svgBlockPattern = /(?:```(?:svg|xml)?\s*)?(<svg\b[\s\S]*?<\/svg\s*>)(?:\s*```)?/gi
+
+  const svgDataUrl = (source: string): string => {
+    const sanitized = String(DOMPurify.sanitize(source, {
+      USE_PROFILES: { svg: true, svgFilters: true },
+      FORBID_TAGS: ['script', 'style', 'foreignobject'],
+      FORBID_ATTR: ['href', 'xlink:href']
+    }))
+    if (!/^<svg(?:\s|>)/i.test(sanitized)) return ''
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sanitized)}`
+  }
+
+  const buildDisplayParts = (content: string): DisplayPart[] => {
+    if (!isAssistant) return [{ type: 'markdown', content }]
+
+    const parts: DisplayPart[] = []
+    let offset = 0
+    for (const match of content.matchAll(svgBlockPattern)) {
+      const index = match.index || 0
+      if (index > offset) parts.push({ type: 'markdown', content: content.slice(offset, index) })
+      const image = svgDataUrl(match[1])
+      parts.push(image
+        ? { type: 'svg', content: image }
+        : { type: 'markdown', content: match[0] })
+      offset = index + match[0].length
+    }
+    if (offset < content.length) parts.push({ type: 'markdown', content: content.slice(offset) })
+    return parts.length ? parts : [{ type: 'markdown', content }]
+  }
+
   const getDisplayMessage = ():string => {
     const content = message.content
     if (isSystem && chatSettings.hideSystemPrompt) {
@@ -51,7 +86,15 @@
   let defaultModel:Model
   let imageUrl:string
   let refreshCounter = 0
-  let displayMessage = message.content
+  let renderedContent:string
+  let displayParts:DisplayPart[] = []
+
+  const updateDisplayParts = () => {
+    const content = getDisplayMessage()
+    if (content === renderedContent) return
+    renderedContent = content
+    displayParts = buildDisplayParts(content)
+  }
 
   onMount(() => {
     defaultModel = chatSettings.model
@@ -60,12 +103,12 @@
         imageUrl = `data:${i.mediaType || 'image/png'};base64,${i.b64image}`
       })
     }
-    displayMessage = getDisplayMessage()
+    updateDisplayParts()
   })
 
   afterUpdate(() => {
     if (message.streaming && message.content.slice(-5).includes('```')) refreshCounter++
-    displayMessage = getDisplayMessage()
+    updateDisplayParts()
   })
 
   const edit = () => {
@@ -276,11 +319,17 @@
         <p><b>Summarizing...</b></p>
         {/if}
         {#key refreshCounter}
-        <SvelteMarkdown
-          source={displayMessage}
-          options={markdownOptions}
-          renderers={markdownRenderers}
-        />
+        {#each displayParts as part}
+          {#if part.type === 'svg'}
+            <img class="generated-svg" src={part.content} alt="Generated SVG">
+          {:else}
+            <SvelteMarkdown
+              source={part.content}
+              options={markdownOptions}
+              renderers={markdownRenderers}
+            />
+          {/if}
+        {/each}
         {/key}
         {#if imageUrl}
           <img src={imageUrl} alt="">

--- a/src/lib/EditMessage.svelte
+++ b/src/lib/EditMessage.svelte
@@ -57,7 +57,7 @@
     defaultModel = chatSettings.model
     if (message?.image) {
       getImage(message.image.id).then(i => {
-        imageUrl = 'data:image/png;base64, ' + i.b64image
+        imageUrl = `data:${i.mediaType || 'image/png'};base64,${i.b64image}`
       })
     }
     displayMessage = getDisplayMessage()

--- a/src/lib/Models.svelte
+++ b/src/lib/Models.svelte
@@ -5,19 +5,14 @@
   import { mergeProfileFields } from './Profiles.svelte'
   import { getChatSettingObjectByKey } from './Settings.svelte'
   import { valueOf } from './Util.svelte'
-  import { chatModels as openAiModels, imageModels as openAiImageModels, fetchRemoteModels, fallbackModelDetail } from './providers/openai/models.svelte'
+  import { chatModels as openAiModels, fetchRemoteModels, fallbackModelDetail } from './providers/openai/models.svelte'
 
 export const supportedChatModels : Record<string, ModelDetail> = {
     ...openAiModels
 }
 
-export const supportedImageModels : Record<string, ModelDetail> = {
-    ...openAiImageModels
-}
-
 const lookupList = {
-    ...supportedChatModels,
-    ...supportedImageModels
+    ...supportedChatModels
 }
 
 Object.entries(lookupList).forEach(([k, v]) => {
@@ -198,22 +193,6 @@ export async function getChatModelOptions (): Promise<SelectOption[]> {
     modelOptionsInactive.sort(sortModelsAlphabetically)
 
     return [...modelOptionsActive, ...modelOptionsInactive]
-}
-
-export async function getImageModelOptions (): Promise<SelectOption[]> {
-    const models = Object.keys(supportedImageModels)
-    const result:SelectOption[] = [{ value: '', text: 'OFF - Disable Image Generation' }]
-    for (let i = 0, l = models.length; i < l; i++) {
-      const model = models[i]
-      const modelDetail = getModelDetail(model)
-      await modelDetail.check(modelDetail)
-      result.push({
-        value: model,
-        text: modelDetail.label || model,
-        disabled: !modelDetail.enabled
-      })
-    }
-    return result
 }
 
 </script>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -95,7 +95,7 @@ const gptDefaults = {
   n: 1,
   stream: true,
   stop: null,
-  max_completion_tokens: 512,
+  max_completion_tokens: 16384,
   presence_penalty: 0,
   frequency_penalty: 0,
   logit_bias: null,
@@ -458,14 +458,13 @@ const chatSettingsList: ChatSetting[] = [
       {
         key: 'max_completion_tokens',
         name: 'Max Tokens',
-        title: 'The maximum number of tokens to generate in the completion.\n' +
-              '\n' +
-              'The token count of your prompt plus max_completion_tokens cannot exceed the model\'s context length. Most models have a context length of 2048 tokens (except for the newest models, which support 4096).\n',
+        title: 'Maximum number of tokens to generate. Defaults to 16,384; leave blank to use the provider and model default.',
+        placeholder: 'Provider default',
         min: 1,
-        max: 32768,
+        max: 128000,
         step: 1,
         type: 'number',
-        forceApi: true // Since default here is different than gpt default, will make sure we always send it
+        forceApi: true
       },
       {
         key: 'presence_penalty',

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -95,7 +95,7 @@ const gptDefaults = {
   n: 1,
   stream: true,
   stop: null,
-  max_completion_tokens: 16384,
+  max_completion_tokens: null,
   presence_penalty: 0,
   frequency_penalty: 0,
   logit_bias: null,
@@ -458,13 +458,12 @@ const chatSettingsList: ChatSetting[] = [
       {
         key: 'max_completion_tokens',
         name: 'Max Tokens',
-        title: 'Maximum number of tokens to generate. Defaults to 16,384; leave blank to use the provider and model default.',
+        title: 'Optional maximum number of tokens to generate. Leave blank to use the provider and model default.',
         placeholder: 'Provider default',
         min: 1,
         max: 128000,
         step: 1,
-        type: 'number',
-        forceApi: true
+        type: 'number'
       },
       {
         key: 'presence_penalty',

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -22,6 +22,13 @@ import { getChatModelOptions, getModelDetail, getTokens } from './Models.svelte'
 import { getImageEndpoint } from './ApiUtil.svelte'
 import { getProvider } from './providers/openai/providers'
 
+const getImageModelHelp = (): string => {
+  const provider = getProvider(getProviderId())
+  return provider.image?.suggestedModel
+    ? `Optional override. Blank uses <code>${provider.image.suggestedModel}</code>.`
+    : 'Enter an image model ID from your provider. Blank disables image generation.'
+}
+
 // We are adding default model names explicitly here to avoid
 // circular dependencies. Alternative would be a big refactor,
 // which we want to avoid for now.
@@ -374,9 +381,9 @@ const summarySettings: ChatSetting[] = [
       {
         key: 'imageGenerationModel',
         name: 'Image Generation Model',
-        header: 'Enter an image model ID from your provider. Leave blank to disable image generation.',
+        header: getImageModelHelp,
         headerClass: 'is-info',
-        title: 'Enter an image model ID, then prompt an image with: show me an image of ...',
+        title: 'Optionally override the provider default, then prompt an image with: show me an image of ...',
         placeholder: () => getProvider(getProviderId()).image?.suggestedModel || 'Image model ID',
         hide: () => !getImageEndpoint(getProviderId()),
         type: 'text'

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
     import { applyProfile } from './Profiles.svelte'
     import { get } from 'svelte/store'
-    import { apiKeyStorage, getChatSettings, getGlobalSettings, setGlobalSettingValueByKey } from './Storage.svelte'
+    import { apiKeyStorage, getChatSettings, getGlobalSettings, getProviderId, setGlobalSettingValueByKey } from './Storage.svelte'
     import { faArrowDown91, faArrowDownAZ, faCheck, faThumbTack } from '@fortawesome/free-solid-svg-icons/index'
 // Setting definitions
 
@@ -19,6 +19,8 @@ import {
 
 } from './Types.svelte'
 import { getChatModelOptions, getModelDetail, getTokens } from './Models.svelte'
+import { getImageEndpoint } from './ApiUtil.svelte'
+import { getProvider } from './providers/openai/providers'
 
 // We are adding default model names explicitly here to avoid
 // circular dependencies. Alternative would be a big refactor,
@@ -372,11 +374,12 @@ const summarySettings: ChatSetting[] = [
       {
         key: 'imageGenerationModel',
         name: 'Image Generation Model',
-        header: 'Image Generation',
+        header: 'Enter an image model ID from your provider. Leave blank to disable image generation.',
         headerClass: 'is-info',
-        title: 'Prompt an image with: show me an image of ...',
-        type: 'select',
-        options: []
+        title: 'Enter an image model ID, then prompt an image with: show me an image of ...',
+        placeholder: () => getProvider(getProviderId()).image?.suggestedModel || 'Image model ID',
+        hide: () => !getImageEndpoint(getProviderId()),
+        type: 'text'
       }
 ]
 

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -55,7 +55,7 @@ export type Request = {
     n?: number;
     stream?: boolean;
     stop?: string | null;
-    max_completion_tokens?: number;
+    max_completion_tokens?: number | null;
     presence_penalty?: number;
     frequency_penalty?: number;
     logit_bias?: Record<string, number> | null;

--- a/src/lib/Types.svelte
+++ b/src/lib/Types.svelte
@@ -6,7 +6,7 @@
 
 export type Model = typeof supportedChatModelKeys[number];
 
-export type RequestType = 'chat' | 'instruct' | 'image'
+export type RequestType = 'chat' | 'instruct'
 
 export type Usage = {
     completion_tokens: number;
@@ -17,8 +17,11 @@ export type Usage = {
 export interface ChatImage {
     id: string;
     b64image: string;
+    mediaType?: string;
     chats: number[];
   }
+
+export type GeneratedImage = Pick<ChatImage, 'b64image' | 'mediaType'>
 
 export type Message = {
     role: 'user' | 'assistant' | 'system' | 'error' | 'image';
@@ -81,7 +84,7 @@ export type ChatSettings = {
     hiddenPromptPrefix: string;
     hppContinuePrompt: string; // hiddenPromptPrefix used, optional glue when trying to continue truncated completion
     hppWithSummaryPrompt: boolean; // include hiddenPromptPrefix when before summary prompt
-    imageGenerationModel: Model;
+    imageGenerationModel: string;
     trainingPrompts?: Message[];
     useResponseAlteration?: boolean;
     responseAlterations?: ResponseAlteration[];

--- a/src/lib/providers/openai/models.svelte
+++ b/src/lib/providers/openai/models.svelte
@@ -1,13 +1,10 @@
 <script context="module" lang="ts">
-  import {
-    getEndpointCompletions,
-    getEndpointGenerations
-  } from '../../ApiUtil.svelte'
+  import { getEndpointCompletions } from '../../ApiUtil.svelte'
   import { countTokens } from '../../Models.svelte'
   import { countMessageTokens } from '../../Stats.svelte'
   import { getApiBase, getProviderId } from '../../Storage.svelte'
   import type { Chat, Message, Model, ModelDetail } from '../../Types.svelte'
-  import { chatRequest, imageRequest } from './request.svelte'
+  import { chatRequest } from './request.svelte'
   import { checkModel, getSupportedModels } from './util.svelte'
   import { encode } from 'gpt-tokenizer'
   import { joinApiUrl } from './providers'
@@ -141,96 +138,4 @@
     return remoteModels
   }
 
-  const imageModelBase = {
-    type: 'image',
-    prompt: 0.0,
-    max: 1000, // 1000 char prompt, max
-    request: imageRequest,
-    check: checkModel,
-    getTokens: (value) => [0],
-    getEndpoint: (model) => joinApiUrl(getApiBase(), getEndpointGenerations(getProviderId())),
-    hideSetting: (chatId, setting) => false
-  } as ModelDetail
-
-  export const imageModels: Record<string, ModelDetail> = {
-    'dall-e-1024x1024': {
-      ...imageModelBase,
-      completion: 0.02, // $0.020 per image
-      opt: {
-        size: '1024x1024'
-      }
-    },
-    'dall-e-512x512': {
-      ...imageModelBase,
-      completion: 0.018, // $0.018 per image
-      opt: {
-        size: '512x512'
-      }
-    },
-    'dall-e-256x256': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.016, // $0.016 per image
-      opt: {
-        size: '256x256'
-      }
-    },
-    'dall-e-3-1024x1024': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.04, // $0.040 per image
-      opt: {
-        model: 'dall-e-3',
-        size: '1024x1024'
-      }
-    },
-    'dall-e-3-1024x1792-Portrait': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.08, // $0.080 per image
-      opt: {
-        model: 'dall-e-3',
-        size: '1024x1792'
-      }
-    },
-    'dall-e-3-1792x1024-Landscape': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.08, // $0.080 per image
-      opt: {
-        model: 'dall-e-3',
-        size: '1792x1024'
-      }
-    },
-    'dall-e-3-1024x1024-HD': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.08, // $0.080 per image
-      opt: {
-        model: 'dall-e-3',
-        size: '1024x1024',
-        quality: 'hd'
-      }
-    },
-    'dall-e-3-1024x1792-Portrait-HD': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.12, // $0.080 per image
-      opt: {
-        model: 'dall-e-3',
-        size: '1024x1792',
-        quality: 'hd'
-      }
-    },
-    'dall-e-3-1792x1024-Landscape-HD': {
-      ...imageModelBase,
-      type: 'image',
-      completion: 0.12, // $0.080 per image
-      opt: {
-        model: 'dall-e-3',
-        size: '1792x1024',
-        quality: 'hd'
-      }
-    }
-  }
 </script>

--- a/src/lib/providers/openai/providers.ts
+++ b/src/lib/providers/openai/providers.ts
@@ -1,26 +1,30 @@
 export type ProviderId = 'openai' | 'anthropic' | 'xai' | 'gemini' | 'mistral' | 'apipie' | 'openrouter' | 'orcarouter' | 'custom'
 
+export type ImageProvider = {
+  endpoint: string
+  suggestedModel?: string
+  responseFormat?: 'b64_json'
+}
+
 export type Provider = {
   id: ProviderId
   name: string
   apiBase: string
   endpoints: {
     completions: string
-    generations: string
     models: string
     embeddings: string
   }
+  image?: ImageProvider
   documentationUrl: string
   apiKeyUrl?: string
   compatibilityNotice?: string
-  supportsImageGeneration: boolean
   headers?: Record<string, string>
   apiKeyHeader?: string
 }
 
 const openAiEndpoints = {
   completions: '/v1/chat/completions',
-  generations: '/v1/images/generations',
   models: '/v1/models',
   embeddings: '/v1/embeddings'
 }
@@ -31,9 +35,12 @@ export const providers: Provider[] = [
     name: 'OpenAI',
     apiBase: 'https://api.openai.com',
     endpoints: openAiEndpoints,
+    image: {
+      endpoint: '/v1/images/generations',
+      suggestedModel: 'gpt-image-2'
+    },
     documentationUrl: 'https://platform.openai.com/docs/api-reference',
-    apiKeyUrl: 'https://platform.openai.com/api-keys',
-    supportsImageGeneration: true
+    apiKeyUrl: 'https://platform.openai.com/api-keys'
   },
   {
     id: 'anthropic',
@@ -43,7 +50,6 @@ export const providers: Provider[] = [
     documentationUrl: 'https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk',
     apiKeyUrl: 'https://console.anthropic.com/settings/keys',
     compatibilityNotice: 'Anthropic supports the OpenAI SDK primarily for testing and comparison. Some OpenAI fields are ignored or translated.',
-    supportsImageGeneration: false,
     apiKeyHeader: 'x-api-key',
     headers: {
       'anthropic-version': '2023-06-01',
@@ -55,9 +61,13 @@ export const providers: Provider[] = [
     name: 'xAI',
     apiBase: 'https://api.x.ai',
     endpoints: openAiEndpoints,
+    image: {
+      endpoint: '/v1/images/generations',
+      suggestedModel: 'grok-imagine-image-quality',
+      responseFormat: 'b64_json'
+    },
     documentationUrl: 'https://docs.x.ai/docs/api-reference',
-    apiKeyUrl: 'https://console.x.ai/',
-    supportsImageGeneration: false
+    apiKeyUrl: 'https://console.x.ai/'
   },
   {
     id: 'gemini',
@@ -65,13 +75,16 @@ export const providers: Provider[] = [
     apiBase: 'https://generativelanguage.googleapis.com/v1beta/openai',
     endpoints: {
       completions: '/chat/completions',
-      generations: '/images/generations',
       models: '/models',
       embeddings: '/embeddings'
     },
+    image: {
+      endpoint: '/images/generations',
+      suggestedModel: 'gemini-2.5-flash-image',
+      responseFormat: 'b64_json'
+    },
     documentationUrl: 'https://ai.google.dev/gemini-api/docs/openai',
-    apiKeyUrl: 'https://aistudio.google.com/app/apikey',
-    supportsImageGeneration: false
+    apiKeyUrl: 'https://aistudio.google.com/app/apikey'
   },
   {
     id: 'mistral',
@@ -79,8 +92,7 @@ export const providers: Provider[] = [
     apiBase: 'https://api.mistral.ai/v1',
     endpoints: openAiEndpoints,
     documentationUrl: 'https://docs.mistral.ai/api',
-    apiKeyUrl: 'https://console.mistral.ai/api-keys',
-    supportsImageGeneration: false
+    apiKeyUrl: 'https://console.mistral.ai/api-keys'
   },
   {
     id: 'apipie',
@@ -88,33 +100,36 @@ export const providers: Provider[] = [
     apiBase: 'https://apipie.ai',
     endpoints: openAiEndpoints,
     documentationUrl: 'https://apipie.ai/',
-    apiKeyUrl: 'https://apipie.ai/dashboard/profile/api-keys',
-    supportsImageGeneration: false
+    apiKeyUrl: 'https://apipie.ai/dashboard/profile/api-keys'
   },
   {
     id: 'openrouter',
     name: 'OpenRouter',
     apiBase: 'https://openrouter.ai/api',
     endpoints: openAiEndpoints,
+    image: {
+      endpoint: '/v1/images'
+    },
     documentationUrl: 'https://openrouter.ai/docs/quickstart',
-    apiKeyUrl: 'https://openrouter.ai/settings/keys',
-    supportsImageGeneration: false
+    apiKeyUrl: 'https://openrouter.ai/settings/keys'
   },
   {
     id: 'orcarouter',
     name: 'OrcaRouter',
     apiBase: 'https://api.orcarouter.ai',
     endpoints: openAiEndpoints,
-    documentationUrl: 'https://docs.orcarouter.ai/',
-    supportsImageGeneration: false
+    documentationUrl: 'https://docs.orcarouter.ai/'
   },
   {
     id: 'custom',
     name: 'Custom OpenAI-compatible',
     apiBase: '',
     endpoints: openAiEndpoints,
-    documentationUrl: 'https://platform.openai.com/docs/api-reference',
-    supportsImageGeneration: true
+    image: {
+      endpoint: '/v1/images/generations',
+      responseFormat: 'b64_json'
+    },
+    documentationUrl: 'https://platform.openai.com/docs/api-reference'
   }
 ]
 

--- a/src/lib/providers/openai/providers.ts
+++ b/src/lib/providers/openai/providers.ts
@@ -146,6 +146,12 @@ export const getProvider = (providerId: ProviderId): Provider => {
   return providerLookup[providerId] || providerLookup.openai
 }
 
+export const resolveImageModel = (providerId: ProviderId, configuredModel = ''): string => {
+  const imageProvider = getProvider(providerId).image
+  if (!imageProvider) return ''
+  return configuredModel.trim() || imageProvider.suggestedModel || ''
+}
+
 export const normalizeApiBase = (apiBase: string): string => {
   return apiBase.trim().replace(/\/+$/, '')
 }

--- a/src/lib/providers/openai/request.svelte
+++ b/src/lib/providers/openai/request.svelte
@@ -6,7 +6,7 @@
     import { getApiBase, getApiKey, getProviderId } from '../../Storage.svelte'
     import type { ChatCompletionOpts, GeneratedImage, Request, Usage } from '../../Types.svelte'
     import { getImageEndpoint } from '../../ApiUtil.svelte'
-    import { getProvider, getProviderHeaders, joinApiUrl } from './providers'
+    import { getProvider, getProviderHeaders, joinApiUrl, resolveImageModel } from './providers'
 
 export const chatRequest = async (
   request: Request,
@@ -141,7 +141,11 @@ export const imageRequest = async (
   }
   chatRequest.updating = true
   chatRequest.updatingMessage = 'Generating Image...'
-  const imageModel = chatSettings.imageGenerationModel.trim()
+  const imageModel = resolveImageModel(providerId, chatSettings.imageGenerationModel)
+  if (!imageModel) {
+    chatResponse.updateFromError(`Choose an image model for ${provider.name}.`)
+    return chatResponse
+  }
   const request: RequestImageGeneration = {
     prompt,
     model: imageModel,

--- a/src/lib/providers/openai/request.svelte
+++ b/src/lib/providers/openai/request.svelte
@@ -1,11 +1,12 @@
 <script context="module" lang="ts">
     import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event-source'
-    import { ChatCompletionResponse } from '../../ChatCompletionResponse.svelte'
-    import { ChatRequest } from '../../ChatRequest.svelte'
-    import { getEndpoint, getModelDetail } from '../../Models.svelte'
-    import { getApiKey, getProviderId } from '../../Storage.svelte'
-    import type { ChatCompletionOpts, Request } from '../../Types.svelte'
-    import { getProviderHeaders } from './providers'
+    import type { ChatCompletionResponse } from '../../ChatCompletionResponse.svelte'
+    import type { ChatRequest } from '../../ChatRequest.svelte'
+    import { getEndpoint } from '../../Models.svelte'
+    import { getApiBase, getApiKey, getProviderId } from '../../Storage.svelte'
+    import type { ChatCompletionOpts, GeneratedImage, Request, Usage } from '../../Types.svelte'
+    import { getImageEndpoint } from '../../ApiUtil.svelte'
+    import { getProvider, getProviderHeaders, joinApiUrl } from './providers'
 
 export const chatRequest = async (
   request: Request,
@@ -87,22 +88,43 @@ export const chatRequest = async (
 }
 
 type ResponseImageDetail = {
-    url: string;
-    b64_json: string;
+    b64_json?: string;
+    media_type?: string;
+    mime_type?: string;
   }
 
 type RequestImageGeneration = {
     prompt: string;
-    n?: number;
-    size?: string;
-    response_format?: keyof ResponseImageDetail;
-    model?: string;
-    quality?: string;
-    style?: string;
+    model: string;
+    n: number;
+    response_format?: 'b64_json';
   }
 
+type ResponseImageGeneration = {
+    data?: ResponseImageDetail[];
+    usage?: Partial<Usage> & {
+      input_tokens?: number;
+      output_tokens?: number;
+    };
+  }
+
+const normalizeImageUsage = (usage?: ResponseImageGeneration['usage']): Usage => {
+  const promptTokens = usage?.prompt_tokens ?? usage?.input_tokens ?? 0
+  const completionTokens = usage?.completion_tokens ?? usage?.output_tokens ?? 0
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: usage?.total_tokens ?? promptTokens + completionTokens
+  }
+}
+
+const normalizeMediaType = (mediaType?: string): string => {
+  if (!mediaType) return 'image/png'
+  if (mediaType.includes('/')) return mediaType
+  return `image/${mediaType === 'jpg' ? 'jpeg' : mediaType}`
+}
+
 export const imageRequest = async (
-  na: Request,
   chatRequest: ChatRequest,
   chatResponse: ChatCompletionResponse,
   opts: ChatCompletionOpts): Promise<ChatCompletionResponse> => {
@@ -110,51 +132,63 @@ export const imageRequest = async (
   const chatSettings = chat.settings
   const count = opts.count || 1
   const prompt = opts.prompt || ''
+  const providerId = getProviderId()
+  const provider = getProvider(providerId)
+  const endpoint = getImageEndpoint(providerId)
+  if (!endpoint) {
+    chatResponse.updateFromError(`Image generation is not supported by ${provider.name}.`)
+    return chatResponse
+  }
   chatRequest.updating = true
   chatRequest.updatingMessage = 'Generating Image...'
-  const imageModel = chatSettings.imageGenerationModel
-  const imageModelDetail = getModelDetail(imageModel)
-  const size = imageModelDetail.opt?.size || '256x256'
-  const model = imageModelDetail.opt?.model
-  const style = imageModelDetail.opt?.style
-  const quality = imageModelDetail.opt?.quality
+  const imageModel = chatSettings.imageGenerationModel.trim()
   const request: RequestImageGeneration = {
-        prompt,
-        response_format: 'b64_json',
-        size,
-        n: count,
-        ...(model ? { model } : {}),
-        ...(style ? { style } : {}),
-        ...(quality ? { quality } : {})
+    prompt,
+    model: imageModel,
+    n: count,
+    ...(provider.image?.responseFormat ? { response_format: provider.image.responseFormat } : {})
   }
   // fetchEventSource doesn't seem to throw on abort,
   // so we deal with it ourselves
   const signal = chatRequest.controller.signal
-  const abortListener = (e:Event) => {
-        chatResponse.updateFromError('User aborted request.')
-        signal.removeEventListener('abort', abortListener)
+  const abortListener = () => {
+    chatRequest.updating = false
+    chatRequest.updatingMessage = ''
+    chatResponse.updateFromError('User aborted request.')
   }
   signal.addEventListener('abort', abortListener)
   // Create request
   const fetchOptions = {
         method: 'POST',
-        headers: getProviderHeaders(getProviderId(), getApiKey()),
+        headers: getProviderHeaders(providerId, getApiKey()),
         body: JSON.stringify(request),
         signal
   }
 
   try {
-        const response = await fetch(getEndpoint(imageModel), fetchOptions)
-        if (!response.ok) {
-          await chatRequest.handleError(response)
-        } else {
-          const json = await response.json()
-          const images = json?.data.map(d => d.b64_json)
-          chatResponse.updateImageFromSyncResponse(images, prompt, imageModel)
-        }
+    const response = await fetch(joinApiUrl(getApiBase(), endpoint), fetchOptions)
+    if (!response.ok) await chatRequest.handleError(response)
+
+    const json = await response.json() as ResponseImageGeneration
+    if (!Array.isArray(json.data) || !json.data.length) {
+      throw new Error('The provider returned an invalid image response.')
+    }
+    const images = json.data.map((image): GeneratedImage => {
+      if (!image.b64_json) {
+        throw new Error('The provider returned an image without base64 data.')
+      }
+      return {
+        b64image: image.b64_json,
+        mediaType: normalizeMediaType(image.media_type || image.mime_type)
+      }
+    })
+    await chatResponse.updateImageFromSyncResponse(images, prompt, imageModel, normalizeImageUsage(json.usage))
   } catch (e) {
-        chatResponse.updateFromError(e)
-        throw e
+    const error = e instanceof Error ? e : new Error(String(e))
+    chatResponse.updateFromError(error.message)
+    throw error
+  } finally {
+    signal.removeEventListener('abort', abortListener)
   }
   return chatResponse
 }

--- a/src/lib/providers/openai/util.svelte
+++ b/src/lib/providers/openai/util.svelte
@@ -3,7 +3,7 @@
     import { get } from 'svelte/store'
     import type { ModelDetail } from '../../Types.svelte'
     import { getEndpointModels } from '../../ApiUtil.svelte'
-    import { getProvider, getProviderHeaders, joinApiUrl, normalizeApiBase, type ProviderId } from './providers'
+    import { getProviderHeaders, joinApiUrl, normalizeApiBase, type ProviderId } from './providers'
 
 type ResponseModels = {
   object?: string;
@@ -79,11 +79,7 @@ export const getSupportedModels = async (): Promise<Record<string, boolean>> => 
 
 export const checkModel = async (modelDetail: ModelDetail) => {
   const supportedModels = await getSupportedModels()
-  if (modelDetail.type === 'chat' || modelDetail.type === 'instruct') {
-        modelDetail.enabled = !!supportedModels[modelDetail.modelQuery || '']
-  } else {
-        modelDetail.enabled = getProvider(getProviderId()).supportsImageGeneration && !!Object.keys(supportedModels).length
-  }
+  modelDetail.enabled = !!supportedModels[modelDetail.modelQuery || '']
 }
 
 </script>


### PR DESCRIPTION
## Summary
- replace the DALL-E pseudo-model registry with optional provider image capabilities
- support image generation through OpenAI GPT Image 2, xAI, Google Gemini, OpenRouter, and compatible custom endpoints
- normalize base64 image responses, MIME types, and usage while adding mock endpoint coverage and documentation

## Validation
- npm run check
- npm run build
- ./node_modules/.bin/eslint .
- Python syntax validation for mocked_api/mock_api.py
- git diff --cached --check